### PR TITLE
Fixed issue with stale tokens on signup/upgrade to paid site.

### DIFF
--- a/packages/sdk/layer1/index.js
+++ b/packages/sdk/layer1/index.js
@@ -22,7 +22,7 @@ module.exports = function layer1(options) {
         });
         return init(gateway).then(function () {
             return gateway;
-        })
+        });
     });
 
     function getToken({audience}) {
@@ -54,7 +54,7 @@ module.exports = function layer1(options) {
     }
 
     return members;
-}
+};
 
 function gatewayFn(method, opts = {}) {
     return function (gateway) {
@@ -66,7 +66,7 @@ function gatewayFn(method, opts = {}) {
                 resolve(res);
             });
         });
-    }
+    };
 }
 
 function loadFrame(src, container = document.body) {

--- a/packages/sdk/layer1/index.js
+++ b/packages/sdk/layer1/index.js
@@ -25,8 +25,8 @@ module.exports = function layer1(options) {
         });
     });
 
-    function getToken({audience}) {
-        return loadGateway.then(gatewayFn('getToken', {audience}));
+    function getToken({audience, fresh}) {
+        return loadGateway.then(gatewayFn('getToken', {audience, fresh}));
     }
 
     function signout() {

--- a/packages/sdk/layer2/index.js
+++ b/packages/sdk/layer2/index.js
@@ -54,8 +54,8 @@ module.exports = function layer2(options) {
         return openAuth('upgrade');
     }
 
-    function getToken({audience}) {
-        return members.getToken({audience});
+    function getToken({audience, fresh}) {
+        return members.getToken({audience, fresh});
     }
 
     function signout() {

--- a/packages/sdk/theme-dropin/package.json
+++ b/packages/sdk/theme-dropin/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@tryghost/content-api": "file:../../content-api",
-    "@tryghost/members-layer1": "../layer1",
+    "@tryghost/content-api": "^1.2.0",
+    "@tryghost/members-layer1": "file:../layer1",
     "@tryghost/members-layer2": "file:../layer2",
     "domready": "^1.0.8",
     "ghost-ignition": "^2.9.6",

--- a/packages/sdk/theme-dropin/src/index.js
+++ b/packages/sdk/theme-dropin/src/index.js
@@ -88,6 +88,15 @@ function setupMembersListeners() {
     function upgrade(event) {
         event.preventDefault();
         members.upgrade()
+            .then(() => {
+                return members.getToken({
+                    audience: tokenAudience,
+                    fresh: true
+                }).then(function (token) {
+                    setCookie(token);
+                    return true;
+                });
+            })
             .then(reload);
     }
 

--- a/packages/sdk/theme-dropin/src/index.js
+++ b/packages/sdk/theme-dropin/src/index.js
@@ -76,7 +76,8 @@ function setupMembersListeners() {
         members.signin()
             .then(() => {
                 return members.getToken({
-                    audience: tokenAudience
+                    audience: tokenAudience,
+                    fresh: true
                 }).then(function (token) {
                     setCookie(token);
                     return true;

--- a/packages/sdk/theme-dropin/yarn.lock
+++ b/packages/sdk/theme-dropin/yarn.lock
@@ -540,8 +540,9 @@
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.2.tgz#16947fce5f57258d01f1688fdc32723093c55d3f"
 
-"@tryghost/content-api@file:../../content-api":
-  version "1.0.0"
+"@tryghost/content-api@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/content-api/-/content-api-1.2.0.tgz#a99cef197cf0e2c08417d6f2062bea29fd2d066a"
   dependencies:
     axios "0.18.0"
     ghost-ignition "^2.9.6"
@@ -553,7 +554,7 @@
     ghost-ignition "^2.9.6"
     lodash "^4.17.11"
 
-"@tryghost/members-layer1@../layer1", "@tryghost/members-layer1@file:../layer1":
+"@tryghost/members-layer1@file:../layer1":
   version "0.0.0"
   dependencies:
     "@tryghost/members-layer0" "file:../../../../../../../.cache/yarn/v2/npm-@tryghost/layer0"


### PR DESCRIPTION
no-issue (@rishabhgrg do we need to make one? or just a note? if it's a note I'm not sure what we doing about ref-ing those in commits etc...)

We had some bugs in the paid site flow, where when a user was to upgrade from free to paid, they would be shown an upgrade button still. This was due to caching of tokens. There was a similar issue that happened when signing up as a paid user.

The fix here ensures that we request a "fresh" token, which will contain the current state of the user and their plans.