### PR TITLE
Updated auth-pages to use new members static url

### DIFF
--- a/packages/members-auth-pages/components/MembersProvider.js
+++ b/packages/members-auth-pages/components/MembersProvider.js
@@ -26,7 +26,7 @@ export default class MembersProvider extends Component {
     }
 
     render({apiUrl, children}) {
-        const src = `${apiUrl}/members/gateway`;
+        const src = `${apiUrl}/static/gateway`;
         return (
             <div>
                 { children }

--- a/packages/members-auth-pages/index.js
+++ b/packages/members-auth-pages/index.js
@@ -7,7 +7,7 @@ import Modal from './components/Modal';
 export default class App extends Component {
     constructor() {
         super();
-        const apiUrl = window.location.href.substring(0, window.location.href.indexOf('/members/auth'));
+        const apiUrl = window.location.href.substring(0, window.location.href.indexOf('/static/auth'));
 
         this.state = {
             apiUrl


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/10886

Since updating the static pages, the auth pages would be broken, this
updates them to correctly parse and load the static urls.