### PR TITLE
Added caching to members-ssr module

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -71,7 +71,8 @@ module.exports = function MembersApi({
         if (member) {
             return member;
         }
-        return users.create({email});
+        await users.create({email});
+        return getMemberIdentityData(email);
     }
     async function getMemberIdentityData(email){
         return users.get({email});


### PR DESCRIPTION
This adds another cookie to the `members-ssr` module to old cached members data - meaning that expensive calls from the `members-api` module are not executed on every request. An extra cookie has been used because it was a) fast and b) still secured with crypto signature.