### PR TITLE
Updated members-ssr to use token from query string

### DIFF
--- a/packages/members-ssr/example.js
+++ b/packages/members-ssr/example.js
@@ -4,66 +4,77 @@ const MembersSSR = require('./');
 const keys = keypair();
 
 const membersApiInstance = {
-    getMember() {
-        return Promise.resolve({name: 'egg'});
+    /**
+     * @param {string} token
+     */
+    async getMemberDataFromMagicLinkToken(token) {
+        return jwt.decode(token);
     },
-    getPublicConfig() {
-        return Promise.resolve({
-            issuer: 'example.com',
-            publicKey: keys.public
-        });
+    async getMemberIdentityData() {
+        return {name: 'egg'};
     }
 };
 
-const {
-    exchangeTokenForSession,
-    getMemberDataFromSession
-} = MembersSSR({
+const membersSSR = MembersSSR({
     cookieSecure: false, // Secure cookie (default)
     cookieKeys: ['some-coole-secret'], // Key to sign cookie with
-    membersApi: membersApiInstance // Used to fetch data and verify tokens
+    getMembersApi: () => membersApiInstance // Used to fetch data and verify tokens
 });
 
-const server = require('http').createServer((req, res) => {
+const server = require('http').createServer(async (req, res) => {
+    if (!req.method) {
+        res.writeHead(405);
+        return res.end('Method not allowed.');
+    }
     if (req.method.toLowerCase() === 'post') {
-        exchangeTokenForSession(req, res).then(() => {
+        try {
+            await membersSSR.exchangeTokenForSession(req, res);
             res.writeHead(200);
             res.end();
-        }).catch((err) => {
+        } catch (err) {
+            console.error(err);
             res.writeHead(err.statusCode);
             res.end(err.message);
-        });
+        }
     } else {
-        getMemberDataFromSession(req, res).then((member) => {
+        try {
+            const member = await membersSSR.getMemberDataFromSession(req, res);
             res.writeHead(200, {
                 'Content-Type': 'application/json'
             });
             res.end(JSON.stringify(member));
-        }).catch((err) => {
+        } catch (err) {
+            console.error(err);
             res.writeHead(err.statusCode);
             res.end(err.message);
-        });
+        }
     }
 });
 
 server.listen(0, '127.0.0.1', () => {
-    const {address, port} = server.address();
+    const addressInfo = server.address();
+    if (addressInfo === null || typeof addressInfo === 'string') {
+        throw new TypeError(`Unexpected return value from server.address(): ${addressInfo}`);
+    }
+    const {address, port} = addressInfo;
     const url = `http://${address}:${port}`;
-    const token = jwt.sign({}, keys.private, {
+
+    const token = jwt.sign({
+        name: 'egg',
+        email: 'egg@mast.er'
+    }, keys.private, {
         issuer: 'example.com',
         audience: 'example.com',
         algorithm: 'RS512'
     });
 
-    require('http').request(url, {
-        method: 'post',
-        headers: {
-            'content-type': 'text'
-        }
+    require('http').request(`${url}?token=${token}`, {
+        method: 'post'
     }, (res) => {
+        const cookies = res.headers['set-cookie'] || [];
         require('http').request(url, {
             headers: {
-                cookie: res.headers['set-cookie'].join('; ')
+                cookie: cookies.join('; ')
             }
         }, (res) => {
             res.pipe(process.stdout);
@@ -71,7 +82,7 @@ server.listen(0, '127.0.0.1', () => {
                 server.close();
             });
         }).end();
-    }).end(token);
+    }).end();
 });
 
 server.on('close', () => {

--- a/packages/members-ssr/index.js
+++ b/packages/members-ssr/index.js
@@ -1,170 +1,326 @@
-const concat = require('concat-stream');
-const Cookies = require('cookies');
+const {parse: parseUrl} = require('url');
+const createCookies = require('cookies');
 const ignition = require('ghost-ignition');
-
 const {
     BadRequestError
 } = ignition.errors;
 
-const EMPTY = {};
+/**
+ * @typedef {import('http').IncomingMessage} Request
+ * @typedef {import('http').ServerResponse} Response
+ * @typedef {import('cookies').ICookies} Cookies
+ * @typedef {import('cookies').Option} CookiesOptions
+ * @typedef {import('cookies').SetOption} SetCookieOptions
+ * @typedef {string} JWT
+ */
+
+/**
+ * @typedef {object} Member
+ * @prop {string} email
+ */
+
 const SIX_MONTHS_MS = 1000 * 60 * 60 * 24 * 184;
 const ONE_DAY_MS = 1000 * 60 * 60 * 24;
 
-const withCookies = (fn, cookieConfig) => (req, res) => {
-    return new Promise((resolve) => {
-        const cookies = new Cookies(req, res, cookieConfig);
-        resolve(fn(req, res, {cookies}));
-    });
-};
+class MembersSSR {
+    /**
+     * @typedef {object} MembersSSROptions
+     *
+     * @prop {string|string[]} cookieKeys - A secret or array of secrets used to sign cookies
+     * @prop {() => object} getMembersApi - A function which returns an instance of members-api
+     * @prop {boolean} [cookieSecure = true] - Whether the cookie should have Secure flag
+     * @prop {string} [cookieName] - The name of the members-ssr cookie
+     * @prop {number} [cookieMaxAge] - The max age in ms of the members-ssr cookie
+     * @prop {string} [cookieCacheName] - The name of the members-ssr-cache cookie
+     * @prop {number} [cookieCacheMaxAge] - The max age in ms of the members-ssr-cache cookie
+     * @prop {string} [cookiePath] - The Path flag for the cookie
+     */
 
-const withBodyAndCookies = (fn, cookieConfig) => (req, res) => {
-    return new Promise((resolve, reject) => {
-        const cookies = new Cookies(req, res, cookieConfig);
-        req.on('error', reject);
-        req.pipe(concat(function (buff) {
-            const body = buff.toString();
-            resolve(fn(req, res, {body, cookies}));
-        }));
-    });
-};
+    /**
+     * Create an instance of MembersSSR
+     *
+     * @param {MembersSSROptions} options  - The options for the members ssr class
+     */
+    constructor(options) {
+        const {
+            cookieSecure = true,
+            cookieName = 'members-ssr',
+            cookieMaxAge = SIX_MONTHS_MS,
+            cookieCacheName = 'members-ssr-cache',
+            cookieCacheMaxAge = ONE_DAY_MS,
+            cookiePath = '/',
+            cookieKeys,
+            getMembersApi
+        } = options;
 
-const get = (value) => {
-    return typeof value === 'function' ? value() : value;
-};
+        if (!getMembersApi) {
+            throw new Error('Missing option getMembersApi');
+        }
 
-module.exports = function create(options = EMPTY) {
-    if (options === EMPTY) {
-        throw new Error('Must pass options');
+        this._getMembersApi = getMembersApi;
+
+        if (!cookieKeys) {
+            throw new Error('Missing option cookieKeys');
+        }
+
+        this.sessionCookieName = cookieName;
+        this.cacheCookieName = cookieCacheName;
+
+        /**
+         * @type SetCookieOptions
+         */
+        this.sessionCookieOptions = {
+            signed: true,
+            httpOnly: true,
+            sameSite: 'lax',
+            maxAge: cookieMaxAge,
+            path: cookiePath
+        };
+
+        /**
+         * @type SetCookieOptions
+         */
+        this.cacheCookieOptions = {
+            signed: true,
+            httpOnly: true,
+            sameSite: 'lax',
+            maxAge: cookieCacheMaxAge,
+            path: cookiePath
+        };
+
+        /**
+         * @type CookiesOptions
+         */
+        this.cookiesOptions = {
+            keys: Array.isArray(cookieKeys) ? cookieKeys : [cookieKeys],
+            secure: cookieSecure
+        };
     }
 
-    const {
-        cookieMaxAge = SIX_MONTHS_MS,
-        cookieSecure = true,
-        cookieName = 'members-ssr',
-        cookieCacheName = 'members-ssr-cache',
-        cookieCacheMaxAge = ONE_DAY_MS,
-        cookiePath = '/',
-        cookieKeys,
-        membersApi
-    } = options;
-
-    if (!membersApi) {
-        throw new Error('Missing option membersApi');
+    /**
+     * @method _getCookies
+     *
+     * @param {Request} req
+     * @param {Response} res
+     *
+     * @returns {Cookies} An instance of the cookies object for current request/response
+     */
+    _getCookies(req, res) {
+        return createCookies(req, res, this.cookiesOptions);
     }
 
-    if (!cookieKeys) {
-        throw new Error('Missing option cookieKeys');
+    /**
+     * @method _removeSessionCookie
+     *
+     * @param {Request} req
+     * @param {Response} res
+     */
+    _removeSessionCookie(req, res) {
+        const cookies = this._getCookies(req, res);
+        cookies.set(this.sessionCookieName, this.sessionCookieOptions);
     }
 
-    const cookieConfig = {
-        keys: [].concat(cookieKeys),
-        secure: cookieSecure
-    };
+    /**
+     * @method _setSessionCookie
+     *
+     * @param {Request} req
+     * @param {Response} res
+     * @param {string} value
+     */
+    _setSessionCookie(req, res, value) {
+        const cookies = this._getCookies(req, res);
+        cookies.set(this.sessionCookieName, value, this.sessionCookieOptions);
+    }
 
-    const getMemberDataFromToken = token => get(membersApi).getMemberDataFromMagicLinkToken(token);
+    /**
+     * @method _getSessionCookies
+     *
+     * @param {Request} req
+     * @param {Response} res
+     *
+     * @returns {string} The cookie value
+     */
+    _getSessionCookies(req, res) {
+        const cookies = this._getCookies(req, res);
+        const value = cookies.get(this.sessionCookieName, {signed: true});
+        if (!value) {
+            throw new BadRequestError({
+                message: `Cookie ${this.sessionCookieName} not found`
+            });
+        }
+        return value;
+    }
 
-    const exchangeTokenForSession = withBodyAndCookies(async (_req, _res, {body, cookies}) => {
-        const token = body;
-        if (!body || typeof body !== 'string') {
+    /**
+     * @method _removeCacheCookie
+     *
+     * @param {Request} req
+     * @param {Response} res
+     */
+    _removeCacheCookie(req, res) {
+        const cookies = this._getCookies(req, res);
+        cookies.set(this.cacheCookieName, this.cacheCookieOptions);
+    }
+
+    /**
+     * @method _setCacheCookie
+     *
+     * @param {Request} req
+     * @param {Response} res
+     * @param {object} value
+     */
+    _setCacheCookie(req, res, value) {
+        const cookies = this._getCookies(req, res);
+        cookies.set(this.cacheCookieName, JSON.stringify(value), this.cacheCookieOptions);
+    }
+
+    /**
+     * @method _getCacheCookie
+     *
+     * @param {Request} req
+     * @param {Response} res
+     *
+     * @returns {object|null} The cookie value
+     */
+    _getCacheCookie(req, res) {
+        const cookies = this._getCookies(req, res);
+        const value = cookies.get(this.cacheCookieName, {signed: true});
+        if (!value) {
+            return null;
+        }
+        try {
+            return JSON.parse(value);
+        } catch (err) {
+            this._removeCacheCookie(req, res);
+            throw new BadRequestError({
+                message: `Invalid JSON found in cookie ${this.cacheCookieName}`
+            });
+        }
+    }
+
+    /**
+     * @method _getMemberDataFromToken
+     *
+     * @param {JWT} token
+     *
+     * @returns {Promise<Member>} member
+     */
+    async _getMemberDataFromToken(token) {
+        const api = await this._getMembersApi();
+        return api.getMemberDataFromMagicLinkToken(token);
+    }
+
+    /**
+     * @method _getMemberIdentityData
+     *
+     * @param {string} email
+     *
+     * @returns {Promise<Member>} member
+     */
+    async _getMemberIdentityData(email) {
+        const api = await this._getMembersApi();
+        return api.getMemberIdentityData(email);
+    }
+
+    /**
+     * @method _getMemberIdentityToken
+     *
+     * @param {string} email
+     *
+     * @returns {Promise<JWT>} member
+     */
+    async _getMemberIdentityToken(email) {
+        const api = await this._getMembersApi();
+        return api.getMemberIdentityToken(email);
+    }
+
+    /**
+     * @method exchangeTokenForSession
+     * @param {Request} req
+     * @param {Response} res
+     *
+     * @returns {Promise<Member>} The member the session was created for
+     */
+    async exchangeTokenForSession(req, res) {
+        if (!req.url) {
             return Promise.reject(new BadRequestError({
-                message: 'Expected body containing JWT'
+                message: 'Expected token param containing JWT'
             }));
         }
 
-        const member = await getMemberDataFromToken(token);
-        cookies.set(cookieName, member.email, {
-            signed: true,
-            httpOnly: true,
-            sameSite: 'lax',
-            maxAge: cookieMaxAge,
-            path: cookiePath
-        });
-        cookies.set(cookieCacheName, JSON.stringify(member), {
-            signed: true,
-            httpOnly: true,
-            sameSite: 'lax',
-            maxAge: cookieCacheMaxAge,
-            path: cookiePath
-        });
-    }, cookieConfig);
-
-    const deleteSession = withCookies((_req, _res, {cookies}) => {
-        cookies.set(cookieName, {
-            signed: true,
-            httpOnly: true,
-            sameSite: 'lax',
-            maxAge: cookieMaxAge,
-            path: cookiePath
-        });
-        cookies.set(cookieCacheName, {
-            signed: true,
-            httpOnly: true,
-            sameSite: 'lax',
-            maxAge: cookieCacheMaxAge,
-            path: cookiePath
-        });
-    }, cookieConfig);
-
-    const getMemberDataFromSession = withCookies(async (_req, _res, {cookies}) => {
-        const email = cookies.get(cookieName, {
-            signed: true
-        });
-
-        if (!email) {
-            throw new BadRequestError({
-                message: `Cookie ${cookieName} not found`
-            });
+        const {query} = parseUrl(req.url, true);
+        if (!query || !query.token) {
+            return Promise.reject(new BadRequestError({
+                message: 'Expected token param containing JWT'
+            }));
         }
 
-        const cachedMember = cookies.get(cookieCacheName, {
-            signed: true
-        });
+        const token = Array.isArray(query.token) ? query.token[0] : query.token;
+        const member = await this._getMemberDataFromToken(token);
 
-        if (cachedMember) {
-            try {
-                return JSON.parse(cachedMember);
-            } catch (e) {
-                cookies.set(cookieCacheName, {
-                    signed: true,
-                    httpOnly: true,
-                    sameSite: 'lax',
-                    maxAge: cookieCacheMaxAge,
-                    path: cookiePath
-                });
-                throw new BadRequestError({
-                    message: `Invalid JSON found in cookie ${cookieCacheName}`
-                });
-            }
-        }
-        const member = await get(membersApi).getMemberIdentityData(email);
-        cookies.set(cookieCacheName, JSON.stringify(member), {
-            signed: true,
-            httpOnly: true,
-            sameSite: 'lax',
-            maxAge: cookieCacheMaxAge,
-            path: cookiePath
-        });
+        this._setSessionCookie(req, res, member.email);
+        this._setCacheCookie(req, res, member);
 
         return member;
-    }, cookieConfig);
+    }
 
-    const getIdentityTokenForMemberFromSession = withCookies(async (_req, _res, {cookies}) => {
-        try {
-            const email = cookies.get(cookieName, {
-                signed: true
-            });
-            return get(membersApi).getMemberIdentityToken(email);
-        } catch (e) {
-            throw new BadRequestError({
-                message: `Cookie ${cookieName} not found`
-            });
+    /**
+     * @method deleteSession
+     * @param {Request} req
+     * @param {Response} res
+     *
+     * @returns {Promise<void>}
+     */
+    async deleteSession(req, res) {
+        this._removeSessionCookie(req, res);
+        this._removeCacheCookie(req, res);
+    }
+
+    /**
+     * @method getMemberDataFromSession
+     *
+     * @param {Request} req
+     * @param {Response} res
+     *
+     * @returns {Promise<Member>}
+     */
+    async getMemberDataFromSession(req, res) {
+        const email = this._getSessionCookies(req, res);
+
+        const cachedMember = this._getCacheCookie(req, res);
+
+        if (cachedMember) {
+            return cachedMember;
         }
-    }, cookieConfig);
 
-    return {
-        exchangeTokenForSession,
-        deleteSession,
-        getMemberDataFromSession,
-        getIdentityTokenForMemberFromSession
-    };
+        const member = await this._getMemberIdentityData(email);
+        this._setCacheCookie(req, res, member);
+        return member;
+    }
+
+    /**
+     * @method getIdentityTokenForMemberFromSession
+     *
+     * @param {Request} req
+     * @param {Response} res
+     *
+     * @returns {Promise<JWT>} identity token
+     */
+    async getIdentityTokenForMemberFromSession(req, res) {
+        const email = this._getSessionCookies(req, res);
+        return this._getMemberIdentityToken(email);
+    }
+}
+
+/**
+ * Factory function for creating instance of MembersSSR
+ *
+ * @param {MembersSSROptions} options
+ * @returns {MembersSSR}
+ */
+module.exports = function create(options) {
+    if (!options) {
+        throw new Error('Must pass options');
+    }
+    return new MembersSSR(options);
 };

--- a/packages/members-ssr/package.json
+++ b/packages/members-ssr/package.json
@@ -16,6 +16,8 @@
     "lib"
   ],
   "devDependencies": {
+    "@types/cookies": "^0.7.2",
+    "@types/node": "^12.7.5",
     "keypair": "1.0.1",
     "mocha": "6.2.0",
     "should": "13.2.3",

--- a/packages/members-ssr/tsconfig.json
+++ b/packages/members-ssr/tsconfig.json
@@ -1,0 +1,66 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "allowJs": true,                       /* Allow javascript files to be compiled. */
+    "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "exclude": [
+    "test"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,10 +826,52 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/body-parser@*":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.1.tgz#18fcf61768fb5c30ccc508c21d6fd2e8b3bf7897"
+  integrity sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.32"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
+  integrity sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/cookies@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.7.2.tgz#5e0560d46ed9998082dce799af1058dd6a49780a"
+  integrity sha512-jnihWgshWystcJKrz8C9hV+Ot9lqOUyAh2RF+o3BEo6K6AS2l4zYCb9GYaBuZ3C6Il59uIGqpE3HvCun4KKeJA==
+  dependencies:
+    "@types/connect" "*"
+    "@types/express" "*"
+    "@types/keygrip" "*"
+    "@types/node" "*"
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
+"@types/express-serve-static-core@*":
+  version "4.16.9"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.9.tgz#69e00643b0819b024bdede95ced3ff239bb54558"
+  integrity sha512-GqpaVWR0DM8FnRUJYKlWgyARoBUAVfRIeVDZQKOttLFp5SmhhF9YFIYeTPwMd/AXfxlP7xVO2dj1fGu0Q+krKQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/range-parser" "*"
+
+"@types/express@*":
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.1.tgz#4cf7849ae3b47125a567dfee18bfca4254b88c5c"
+  integrity sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
 
 "@types/glob@^7.1.1":
   version "7.1.1"
@@ -847,6 +889,16 @@
   dependencies:
     "@types/node" "*"
 
+"@types/keygrip@*":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.1.tgz#ff540462d2fb4d0a88441ceaf27d287b01c3d878"
+  integrity sha1-/1QEYtL7TQqIRBzq8n0oewHD2Hg=
+
+"@types/mime@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
+  integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -862,6 +914,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.4.tgz#64db61e0359eb5a8d99b55e05c729f130a678b04"
   integrity sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==
 
+"@types/node@^12.7.5":
+  version "12.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"
+  integrity sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==
+
 "@types/nodemailer@6.2.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.2.1.tgz#8f089bf0ef826f04b9d8dd8750233b04978cb675"
@@ -873,6 +930,19 @@
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/range-parser@*":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
+  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/serve-static@*":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
+  integrity sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/mime" "*"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"


### PR DESCRIPTION
no-issue

This changes the exchangeTokenForSession method to read the token from a
`token` query string, rather than from the request body.

This also includes a refactor to change MembersSSR into a class, and
document all methods with JsDoc type annotations which can be
interpreted by the typescript compiler