### PR TITLE
Added public_id to member object

### DIFF
--- a/packages/members-api/lib/users.js
+++ b/packages/members-api/lib/users.js
@@ -1,3 +1,5 @@
+const hash = str => require('crypto').createHash('sha256').update(str).digest('base64');
+
 module.exports = function ({
     sendEmailWithMagicLink,
     stripe,
@@ -15,6 +17,7 @@ module.exports = function ({
 
         if (!stripe) {
             return Object.assign(member, {
+                public_id: hash(member.id),
                 stripe: {
                     subscriptions: []
                 }
@@ -24,6 +27,7 @@ module.exports = function ({
             const subscriptions = await stripe.getActiveSubscriptions(member);
 
             return Object.assign(member, {
+                public_id: hash(member.id),
                 stripe: {
                     subscriptions
                 }


### PR DESCRIPTION
no-issue

We use the base64 encoded sha256 hash of the members id to generate
this, base64 means the id is fairly small, and sha256 means the
operation should be irreversible.