### PR TITLE
Support for multiple magic-link email templates

### DIFF
--- a/packages/magic-link/test/index.test.js
+++ b/packages/magic-link/test/index.test.js
@@ -22,7 +22,7 @@ describe('MagicLink', function () {
     });
 
     describe('#sendMagicLink', function () {
-        it('Sends an email to the user with a link generated from getSigninURL(token)', async function () {
+        it('Sends an email to the user with a link generated from getSigninURL(token, type)', async function () {
             const options = {
                 publicKey,
                 privateKey,
@@ -39,12 +39,13 @@ describe('MagicLink', function () {
                 email: 'test@example.com',
                 user: {
                     id: 420
-                }
+                },
+                type: 'blazeit'
             };
             const {token} = await service.sendMagicLink(args);
 
             should.ok(options.getSigninURL.calledOnce);
-            should.ok(options.getSigninURL.firstCall.calledWithExactly(token));
+            should.ok(options.getSigninURL.firstCall.calledWithExactly(token, 'blazeit'));
 
             should.ok(options.transporter.sendMail.calledOnce);
             should.equal(options.transporter.sendMail.firstCall.args[0].to, args.email);

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -61,8 +61,8 @@ module.exports = function MembersApi({
         getSigninURL
     });
 
-    async function sendEmailWithMagicLink(email){
-        return magicLinkService.sendMagicLink({email, user: {email}});
+    async function sendEmailWithMagicLink(email, type){
+        return magicLinkService.sendMagicLink({email, user: {email}, type});
     }
 
     const users = Users({
@@ -108,8 +108,9 @@ module.exports = function MembersApi({
             res.writeHead(400);
             return res.end('Bad Request.');
         }
+        const emailType = req.body.emailType;
         try {
-            await sendEmailWithMagicLink(email);
+            await sendEmailWithMagicLink(email, emailType);
             res.writeHead(201);
             return res.end('Created.');
         } catch (err) {
@@ -171,7 +172,8 @@ module.exports = function MembersApi({
 
             await stripe.addCustomerToMember(member, customer);
 
-            await sendEmailWithMagicLink(customer.email);
+            const emailType = 'signup';
+            await sendEmailWithMagicLink(customer.email, emailType);
             res.writeHead(200);
             res.end();
         } catch (err) {

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -18,7 +18,9 @@ module.exports = function MembersApi({
     },
     paymentConfig,
     mail: {
-        transporter
+        transporter,
+        getText,
+        getHTML
     },
     setMemberMetadata,
     getMemberMetadata,
@@ -58,7 +60,9 @@ module.exports = function MembersApi({
         transporter,
         publicKey,
         privateKey,
-        getSigninURL
+        getSigninURL,
+        getText,
+        getHTML
     });
 
     async function sendEmailWithMagicLink(email, type){


### PR DESCRIPTION
no-issue

This allows for multiple magic-link email templates by passing in a `type` parameter