### PR TITLE
Added priority to webhook secret if present in env

### DIFF
--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -62,7 +62,7 @@ module.exports = class StripePaymentProcessor {
                         'invoice.payment_failed'
                     ]
                 });
-                this._webhookSecret = webhook.secret;
+                this._webhookSecret = process.env.WEBHOOK_SECRET || webhook.secret;
             } catch (err) {
                 this.logging.warn(err);
                 this._webhookSecret = process.env.WEBHOOK_SECRET;

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -65,7 +65,6 @@ module.exports = class StripePaymentProcessor {
                 this._webhookSecret = process.env.WEBHOOK_SECRET || webhook.secret;
             } catch (err) {
                 this.logging.warn(err);
-                this._webhookSecret = process.env.WEBHOOK_SECRET;
             }
             debug(`Webhook secret set to ${this._webhookSecret}`);
         } catch (err) {


### PR DESCRIPTION
no issue 

- When debugging Stripe with using: `stripe listen \
  --forward-to http://ghost.local/members/webhooks/stripe/` 
- This priority (fallback) is nice to have so that Ghost process can be initialized using WEBHOOK_SECRET env variable

@allouis had bumped into this issue a couple of times already. Think it makes sense or I'm missing something when using local instance?