### PR TITLE
Changed members-api constructor to accept Member model directly

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -27,11 +27,7 @@ module.exports = function MembersApi({
     },
     setMetadata,
     getMetadata,
-    createMember,
-    getMember,
-    updateMember,
-    deleteMember,
-    listMembers,
+    memberModel,
     logger
 }) {
     if (logger) {
@@ -89,11 +85,7 @@ module.exports = function MembersApi({
     const users = Users({
         sendEmailWithMagicLink,
         stripe,
-        createMember,
-        getMember,
-        updateMember,
-        deleteMember,
-        listMembers
+        memberModel
     });
 
     async function getMemberDataFromMagicLinkToken(token){


### PR DESCRIPTION
Refactor that allows member-api to use Ghost member models directly, also reduces member-api constructor signature.

Note: would require a minor bump because of the constructor signature change

@allouis would be great if you could verify if I understood the needed refactor correctly and this is the right direction :arrow_forward: 