### PR TITLE
Added subscription update middleware

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -239,7 +239,9 @@ module.exports = function MembersApi({
         let email;
         try {
             if (!identity) {
-                email = null;
+                throw new common.errors.BadRequestError({
+                    message: 'Cancel membership failed! Could not find member'
+                });
             } else {
                 const claims = await decodeToken(identity);
                 email = claims.sub;

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -234,7 +234,7 @@ module.exports = function MembersApi({
 
     middleware.cancelSubscription.use(ensureStripe, body.json(), async function (req, res) {
         const identity = req.body.identity;
-        const cancel = req.body.cancel;
+        const cancelAtPeriodEnd = req.body.cancel_at_period_end;
         const subscriptionId = req.params.id;
 
         let member;
@@ -268,13 +268,13 @@ module.exports = function MembersApi({
             return res.end('No permission');
         }
 
-        if (cancel === undefined) {
+        if (cancelAtPeriodEnd === undefined) {
             throw new common.errors.BadRequestError({
                 message: 'Cancel membership failed! Should provide "cancel" field'
             });
         }
 
-        subscription.cancel_at_period_end = cancel;
+        subscription.cancel_at_period_end = cancelAtPeriodEnd;
 
         await stripe.updateSubscriptionFromClient(subscription);
 

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -263,9 +263,13 @@ module.exports = function MembersApi({
         // Don't allow removing subscriptions that don't belong to the member
         const subscription = member.stripe.subscriptions.find(sub => sub.id === subscriptionId);
 
-        if (cancel !== undefined) {
-            subscription.cancel_at_period_end = cancel;
+        if (cancel === undefined) {
+            throw new common.errors.BadRequestError({
+                message: 'Cancel membership failed! Should provide "cancel" field'
+            });
         }
+
+        subscription.cancel_at_period_end = cancel;
 
         if (!subscription) {
             res.writeHead(403);

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -275,7 +275,7 @@ module.exports = function MembersApi({
             });
         }
 
-        subscription.cancel_at_period_end = cancelAtPeriodEnd;
+        subscription.cancel_at_period_end = !!(cancelAtPeriodEnd);
 
         await stripe.updateSubscriptionFromClient(subscription);
 

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -115,7 +115,7 @@ module.exports = function MembersApi({
         sendMagicLink: Router(),
         createCheckoutSession: Router(),
         handleStripeWebhook: Router(),
-        cancelSubscription: Router({mergeParams: true})
+        updateSubscription: Router({mergeParams: true})
     };
 
     middleware.sendMagicLink.use(body.json(), async function (req, res) {
@@ -232,7 +232,7 @@ module.exports = function MembersApi({
         }
     });
 
-    middleware.cancelSubscription.use(ensureStripe, body.json(), async function (req, res) {
+    middleware.updateSubscription.use(ensureStripe, body.json(), async function (req, res) {
         const identity = req.body.identity;
         const cancelAtPeriodEnd = req.body.cancel_at_period_end;
         const subscriptionId = req.params.id;

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -263,6 +263,11 @@ module.exports = function MembersApi({
         // Don't allow removing subscriptions that don't belong to the member
         const subscription = member.stripe.subscriptions.find(sub => sub.id === subscriptionId);
 
+        if (!subscription) {
+            res.writeHead(403);
+            return res.end('No permission');
+        }
+
         if (cancel === undefined) {
             throw new common.errors.BadRequestError({
                 message: 'Cancel membership failed! Should provide "cancel" field'
@@ -270,11 +275,6 @@ module.exports = function MembersApi({
         }
 
         subscription.cancel_at_period_end = cancel;
-
-        if (!subscription) {
-            res.writeHead(403);
-            return res.end('No permission');
-        }
 
         await stripe.updateSubscriptionFromClient(subscription);
 

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -260,14 +260,14 @@ module.exports = function MembersApi({
         }
 
         // Don't allow removing subscriptions that don't belong to the member
-        const hasSubscription = member.stripe.subscriptions.some(sub => sub.id === subscriptionId);
+        const subscription = member.stripe.subscriptions.find(sub => sub.id === subscriptionId);
 
-        if (!hasSubscription) {
+        if (!subscription) {
             res.writeHead(403);
             return res.end('No permission');
         }
 
-        await stripe.cancelSubscription(subscriptionId);
+        await stripe.cancelSubscription(subscription);
 
         res.writeHead(204);
         res.end();

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -270,7 +270,8 @@ module.exports = function MembersApi({
 
         if (cancelAtPeriodEnd === undefined) {
             throw new common.errors.BadRequestError({
-                message: 'Cancel membership failed! Should provide "cancel" field'
+                message: 'Canceling membership failed!',
+                help: 'Request should contain boolean "cancel" field.'
             });
         }
 

--- a/packages/members-api/lib/common.js
+++ b/packages/members-api/lib/common.js
@@ -14,5 +14,9 @@ module.exports = {
                 Object.assign(loggerInterface, Object.create(newLogger));
             }
         });
+    },
+
+    get errors() {
+        return require('ghost-ignition').errors;
     }
 };

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -173,6 +173,7 @@ module.exports = class StripePaymentProcessor {
                 status: subscription.status,
                 start_date: subscription.start_date,
                 default_payment_card_last4: subscription.default_payment_card_last4,
+                cancel_at_period_end: subscription.cancel_at_period_end,
                 current_period_end: subscription.current_period_end
             };
         });

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -135,6 +135,10 @@ module.exports = class StripePaymentProcessor {
         return true;
     }
 
+    async cancelSubscription(id) {
+        return del(this._stripe, 'subscriptions', id);
+    }
+
     async getSubscriptions(member) {
         const metadata = await this.storage.get(member);
 

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -185,19 +185,6 @@ module.exports = class StripePaymentProcessor {
         });
     }
 
-    /**
-     * Handles immediate subscription deletion
-     * @param {Object} subscription
-     */
-    async handleCustomerSubscriptionDelete(subscription) {
-        return await this.storage.set({
-            subscription: {
-                subscription_id: subscription.id,
-                status: 'canceled'
-            }
-        });
-    }
-
     async handleCheckoutSessionCompletedWebhook(member, customer) {
         await this._updateCustomer(member, customer);
         if (!customer.subscriptions || !customer.subscriptions.data) {

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -195,10 +195,6 @@ module.exports = class StripePaymentProcessor {
         }
     }
 
-    /**
-     * Handles subscription deletion that comes from async source, e.g.: webhook
-     * @param {Object} subscription
-     */
     async handleCustomerSubscriptionDeletedWebhook(subscription) {
         await this._updateSubscription(subscription);
     }

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -128,9 +128,7 @@ module.exports = class StripePaymentProcessor {
             return subscription.status !== 'canceled';
         });
 
-        await Promise.all(activeSubscriptions.map(async (subscription) => {
-            await this.handleCustomerSubscriptionDelete(subscription);
-
+        await Promise.all(activeSubscriptions.map((subscription) => {
             return del(this._stripe, 'subscriptions', subscription.id);
         }));
 


### PR DESCRIPTION
Adds the ability to cancel member's subscriptions.

@allouis a structural question about this change. 
(i) Have placed validation handling (if the subscription exists and belongs to the member) in the route handler itself. Was wondering if this kind of checks might belong on the stripe class itself? 

(ii) Another topic is how the deletion is handled on our side. Right now the flow would be following:
1. Member visits the "account" page
2. Clicks on "cancel subscription" button
3. The request to cancel the subscription goes out to Stripe.
  3.1. At some point, webhook about the cancellation comes back and we remove the record in the DB.
4. Frontend receives confirmation and member refreshes the page and still sees the subscription.
5. Refreshes again and it's gone (webhook came through)

Should we be removing the record in the db in pt.3 as well :thinking: this would prevent the pt. 4 being a little confusing. 

Sidenote. Will bring up a topic of the policy of cancellation in separate thread (if we should cancel immediately or for example use [cancel_at_period_end](https://stripe.com/docs/api/subscriptions/object#subscription_object-cancel_at_period_end) instead. 