### PR TITLE
🐛 Fixed incorrect fetch of empty stripe subscriptions

### DIFF
--- a/packages/members-api/lib/users.js
+++ b/packages/members-api/lib/users.js
@@ -63,7 +63,7 @@ module.exports = function ({
 
     async function getStripeSubscriptions(member) {
         if (!stripe) {
-            return {subscriptions: []};
+            return [];
         }
 
         return await stripe.getActiveSubscriptions(member);


### PR DESCRIPTION
refs https://github.com/TryGhost/Members/commit/aa7c76a1d06aaae7ef9958cd5a60becc5db2ad62

While refactoring user CRUD for Ghost core, we inadvertently changed the members subscriptions object returned by nesting the value as object. This also broke the deserialization in Ghost-Admin for members subscription object [here](https://github.com/TryGhost/Ghost-Admin/blob/master/app/transforms/member-subscription.js#L9).