### PR TITLE
✨ Added "complimentary" subscription handling

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -154,6 +154,12 @@ module.exports = function MembersApi({
             return res.end('Bad Request.');
         }
 
+        // NOTE: never allow "Complimenatry" plan to be subscribed to from the client
+        if (plan.toLowerCase() === 'complimentary') {
+            res.writeHead(400);
+            return res.end('Bad Request.');
+        }
+
         let email;
         try {
             if (!identity) {

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -276,6 +276,11 @@ module.exports = function MembersApi({
             return res.end('No permission');
         }
 
+        if (subscription.plan.nickname === 'Complimentary') {
+            res.writeHead(400);
+            return res.end('Bad request');
+        }
+
         if (cancelAtPeriodEnd === undefined) {
             throw new common.errors.BadRequestError({
                 message: 'Canceling membership failed!',

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -182,9 +182,9 @@ module.exports = class StripePaymentProcessor {
         const complimentaryPlan = this._plans.find(plan => (plan.nickname === 'Complimentary'));
 
         // TODO: check if already on any plan or is on the "Complimentary" one
-        if (!subscriptions.customers) {
+        if (!subscriptions.length) {
             const customer = await create(this._stripe, 'customers', {
-                email: member.email
+                email: member.email || member.get('email')
             });
 
             await this._updateCustomer(member, customer);

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -207,7 +207,7 @@ module.exports = class StripePaymentProcessor {
 
     async cancelComplimentarySubscription(member) {
         // NOTE: a more explicit way would be cancelling just the "Complimentary" subscription, but doing it
-        //        through existing method achieves the same as there should be only one subscription at a time
+        //       through existing method achieves the same as there should be only one subscription at a time
         await this.cancelAllSubscriptions(member);
     }
 

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -200,6 +200,7 @@ module.exports = class StripePaymentProcessor {
                     proration_behavior: 'none',
                     plan: complimentaryPlan.id
                 });
+
                 await this._updateSubscription(updatedSubscription);
             }
         }

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -128,9 +128,10 @@ module.exports = class StripePaymentProcessor {
             return subscription.status !== 'canceled';
         });
 
-        await Promise.all(activeSubscriptions.map((subscription) => {
-            return del(this._stripe, 'subscriptions', subscription.id);
-        }));
+        for (const subscription of activeSubscriptions) {
+            const updatedSubscription = await del(this._stripe, 'subscriptions', subscription.id);
+            await await this._updateSubscription(updatedSubscription);
+        }
 
         return true;
     }

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -199,6 +199,12 @@ module.exports = class StripePaymentProcessor {
         }
     }
 
+    async cancelComplimentarySubscription(member) {
+        // NOTE: a more explicit way would be cancelling just the "Complimentary" subscription, but doing it
+        //        through existing method achieves the same as there should be only one subscription at a time
+        await this.cancelAllSubscriptions(member);
+    }
+
     async getActiveSubscriptions(member) {
         const subscriptions = await this.getSubscriptions(member);
 

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -177,6 +177,28 @@ module.exports = class StripePaymentProcessor {
         });
     }
 
+    async setComplimentarySubscription(member) {
+        const subscriptions = await this.getSubscriptions(member);
+        const complimentaryPlan = this._plans.find(plan => (plan.nickname === 'Complimentary'));
+
+        // TODO: check if already on any plan or is on the "Complimentary" one
+        if (!subscriptions.customers) {
+            const customer = await create(this._stripe, 'customers', {
+                email: member.email
+            });
+
+            await this._updateCustomer(member, customer);
+            const subscription = await create(this._stripe, 'subscriptions', {
+                customer: customer.id,
+                items: [{
+                    plan: complimentaryPlan.id
+                }]
+            });
+
+            await this._updateSubscription(subscription);
+        }
+    }
+
     async getActiveSubscriptions(member) {
         const subscriptions = await this.getSubscriptions(member);
 

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -130,7 +130,7 @@ module.exports = class StripePaymentProcessor {
 
         for (const subscription of activeSubscriptions) {
             const updatedSubscription = await del(this._stripe, 'subscriptions', subscription.id);
-            await await this._updateSubscription(updatedSubscription);
+            await this._updateSubscription(updatedSubscription);
         }
 
         return true;

--- a/packages/members-api/lib/users.js
+++ b/packages/members-api/lib/users.js
@@ -81,6 +81,12 @@ module.exports = function ({
         }
     }
 
+    async function cancelComplimentarySubscription(member) {
+        if (stripe) {
+            await stripe.cancelComplimentarySubscription(member);
+        }
+    }
+
     async function get(data, options) {
         debug(`get id:${data.id} email:${data.email}`);
         const member = await getMember(data, options);

--- a/packages/members-api/lib/users.js
+++ b/packages/members-api/lib/users.js
@@ -75,6 +75,12 @@ module.exports = function ({
         }
     }
 
+    async function setComplimentarySubscription(member) {
+        if (stripe) {
+            await stripe.setComplimentarySubscription(member);
+        }
+    }
+
     async function get(data, options) {
         debug(`get id:${data.id} email:${data.email}`);
         const member = await getMember(data, options);
@@ -146,6 +152,8 @@ module.exports = function ({
         get,
         destroy,
         getStripeSubscriptions,
+        setComplimentarySubscription,
+        cancelComplimentarySubscription,
         destroyStripeSubscriptions
     };
 };


### PR DESCRIPTION
Handling of of "Complimentary" (comp) subscription for members.

TODO: 
- [x] Customer creation for comp. subscription
- [x] comp. subscription assignment to member when no other subscriptions
- [x] Assigning comp. subscription to member with existing subscriptions
- [x] Cancelling comp. subscriptions, basic scenario
  - [x] :bug: cancelling doesn't allow to assign a new subscription, there is  possible error in handling subscription cancellation in general as records stay untouched in the DB
