### PR TITLE
✨ Added ability to add labels to member signup

### DIFF
--- a/packages/magic-link/index.js
+++ b/packages/magic-link/index.js
@@ -90,7 +90,7 @@ function MagicLink(options) {
  */
 MagicLink.prototype.sendMagicLink = async function sendMagicLink(options) {
     const payload = options.payload || {};
-    const token = jwt.sign({payload}, this.secret, {
+    const token = jwt.sign(payload, this.secret, {
         algorithm: 'HS256',
         subject: options.subject,
         expiresIn: '10m'
@@ -156,5 +156,5 @@ MagicLink.prototype.getPayloadFromToken = function getPayloadFromToken(token) {
         algorithms: ['HS256'],
         maxAge: '10m'
     });
-    return claims.payload || {};
+    return claims || {};
 };

--- a/packages/magic-link/index.js
+++ b/packages/magic-link/index.js
@@ -83,18 +83,14 @@ function MagicLink(options) {
  *
  * @param {object} options
  * @param {string} options.email - The email to send magic link to
- * @param {string} options.labels - The labels for member
+ * @param {string} options.payload - The payload for token
  * @param {object} options.subject - The subject to associate with the magic link (user id, or email)
  * @param {string=} [options.type='signin'] - The type to be passed to the url and content generator functions
  * @returns {Promise<{token: JSONWebToken, info: SentMessageInfo}>}
  */
 MagicLink.prototype.sendMagicLink = async function sendMagicLink(options) {
-    const labels = options.labels;
-    const payload = {};
-    if (labels) {
-        payload.labels = labels;
-    }
-    const token = jwt.sign(payload, this.secret, {
+    const payload = options.payload || {};
+    const token = jwt.sign({payload}, this.secret, {
         algorithm: 'HS256',
         subject: options.subject,
         expiresIn: '10m'
@@ -149,16 +145,16 @@ MagicLink.prototype.getUserFromToken = function getUserFromToken(token) {
 };
 
 /**
- * getLabelsFromToken
+ * getPayloadFromToken
  *
  * @param {JSONWebToken} token - The token to decode
- * @returns {object} labels - The labels object associated with the magic link
+ * @returns {object} payload - The payload object associated with the magic link
  */
-MagicLink.prototype.getLabelsFromToken = function getLabelsFromToken(token) {
+MagicLink.prototype.getPayloadFromToken = function getPayloadFromToken(token) {
     /** @type {object} */
     const claims = jwt.verify(token, this.secret, {
         algorithms: ['HS256'],
         maxAge: '10m'
     });
-    return claims.labels;
+    return claims.payload || {};
 };

--- a/packages/magic-link/index.js
+++ b/packages/magic-link/index.js
@@ -83,12 +83,18 @@ function MagicLink(options) {
  *
  * @param {object} options
  * @param {string} options.email - The email to send magic link to
+ * @param {string} options.labels - The labels for member
  * @param {object} options.subject - The subject to associate with the magic link (user id, or email)
  * @param {string=} [options.type='signin'] - The type to be passed to the url and content generator functions
  * @returns {Promise<{token: JSONWebToken, info: SentMessageInfo}>}
  */
 MagicLink.prototype.sendMagicLink = async function sendMagicLink(options) {
-    const token = jwt.sign({}, this.secret, {
+    const labels = options.labels;
+    const payload = {};
+    if (labels) {
+        payload.labels = labels;
+    }
+    const token = jwt.sign(payload, this.secret, {
         algorithm: 'HS256',
         subject: options.subject,
         expiresIn: '10m'
@@ -140,4 +146,19 @@ MagicLink.prototype.getUserFromToken = function getUserFromToken(token) {
         maxAge: '10m'
     });
     return claims.sub;
+};
+
+/**
+ * getLabelsFromToken
+ *
+ * @param {JSONWebToken} token - The token to decode
+ * @returns {object} labels - The labels object associated with the magic link
+ */
+MagicLink.prototype.getLabelsFromToken = function getLabelsFromToken(token) {
+    /** @type {object} */
+    const claims = jwt.verify(token, this.secret, {
+        algorithms: ['HS256'],
+        maxAge: '10m'
+    });
+    return claims.labels;
 };

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -72,16 +72,16 @@ module.exports = function MembersApi({
         getSubject
     });
 
-    async function sendEmailWithMagicLink(email, requestedType, options = {forceEmailType: false}){
+    async function sendEmailWithMagicLink({email, requestedType, labels, options = {forceEmailType: false}}){
         if (options.forceEmailType) {
-            return magicLinkService.sendMagicLink({email, subject: email, type: requestedType});
+            return magicLinkService.sendMagicLink({email, labels, subject: email, type: requestedType});
         }
         const member = await users.get({email});
         if (member) {
-            return magicLinkService.sendMagicLink({email, subject: email, type: 'signin'});
+            return magicLinkService.sendMagicLink({email, labels, subject: email, type: 'signin'});
         } else {
             const type = requestedType === 'subscribe' ? 'subscribe' : 'signup';
-            return magicLinkService.sendMagicLink({email, subject: email, type});
+            return magicLinkService.sendMagicLink({email, labels, subject: email, type});
         }
     }
 
@@ -99,11 +99,21 @@ module.exports = function MembersApi({
         if (!email) {
             return null;
         }
+        /** Since we pass labels as comma-seperated string in token, it needs proper formatting for member creation*/
+        let labels = await magicLinkService.getLabelsFromToken(token) || [];
+        if (_.isString(labels)) {
+            labels = labels.split(',').map((label) => {
+                return {
+                    name: label
+                };
+            });
+        }
+
         const member = await getMemberIdentityData(email);
         if (member) {
             return member;
         }
-        await users.create({email});
+        await users.create({email, labels});
         return getMemberIdentityData(email);
     }
     async function getMemberIdentityData(email){
@@ -131,14 +141,15 @@ module.exports = function MembersApi({
             return res.end('Bad Request.');
         }
         const emailType = req.body.emailType;
+        const labels = req.body.labels;
         try {
             if (!allowSelfSignup) {
                 const member = await users.get({email});
                 if (member) {
-                    await sendEmailWithMagicLink(email, emailType);
+                    await sendEmailWithMagicLink({email, requestedType: emailType});
                 }
             } else {
-                await sendEmailWithMagicLink(email, emailType);
+                await sendEmailWithMagicLink({email, requestedType: emailType, labels});
             }
             res.writeHead(201);
             return res.end('Created.');
@@ -238,7 +249,7 @@ module.exports = function MembersApi({
                 }
 
                 const emailType = 'signup';
-                await sendEmailWithMagicLink(customer.email, emailType, {forceEmailType: true});
+                await sendEmailWithMagicLink({email: customer.email, requestedType: emailType, options: {forceEmailType: true}});
             }
 
             res.writeHead(200);

--- a/packages/members-api/lib/users.js
+++ b/packages/members-api/lib/users.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const debug = require('ghost-ignition').debug('users');
 const common = require('./common');
 
@@ -154,6 +155,16 @@ module.exports = function ({
 
     async function create(data) {
         debug(`create email:${data.email}`);
+
+        /** Member.add model method expects label object array*/
+        if (data.labels) {
+            data.labels.forEach((label, index) => {
+                if (_.isString(label)) {
+                    data.labels[index] = {name: label};
+                }
+            });
+        }
+
         const member = await createMember(data);
         return member;
     }

--- a/packages/members-api/lib/users.js
+++ b/packages/members-api/lib/users.js
@@ -3,11 +3,12 @@ const common = require('./common');
 
 let Member;
 
-async function createMember({email, name, note}) {
+async function createMember({email, name, note, labels}) {
     const model = await Member.add({
         email,
         name,
-        note
+        note,
+        labels
     });
     const member = model.toJSON();
     return member;


### PR DESCRIPTION
no issue

refs https://github.com/TryGhost/Ghost/pull/11538/files

We are adding new ability for site-owners to tag members using labels and perform actions like filtering using labels on Admin. We want site owners/theme builders to be able to tag members through the signup process, and corresponding label(s) should be saved to them respectively.

This PR adds ability in members-api package to use `data-members-label` property from theme for assigning labels to members during signup flow.

- Updates `sendMagicLink` middleware to read `labels` from request body
- Allows magic link email method to use labels
- Updates magic link token generation to encode labels if exist
- Read labels from magic link token data for member creation
- Updates member creation to pass labels