### PR TITLE
Added metadata to stripe checkout session for member name

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -218,7 +218,8 @@ module.exports = function MembersApi({
         const sessionInfo = await stripe.createCheckoutSession(member, plan, {
             successUrl: req.body.successUrl,
             cancelUrl: req.body.cancelUrl,
-            customerEmail: req.body.customerEmail
+            customerEmail: req.body.customerEmail,
+            metadata: req.body.metadata
         });
 
         res.writeHead(200, {

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -115,12 +115,14 @@ module.exports = class StripePaymentProcessor {
         }
         const plan = this._plans.find(plan => plan.nickname === planName);
         const customerEmail = (!customer && options.customerEmail) ? options.customerEmail : undefined;
+        const metadata = options.metadata || undefined;
         const session = await this._stripe.checkout.sessions.create({
             payment_method_types: ['card'],
             success_url: options.successUrl || this._checkoutSuccessUrl,
             cancel_url: options.cancelUrl || this._checkoutCancelUrl,
             customer: customer ? customer.id : undefined,
             customer_email: customerEmail,
+            metadata,
             subscription_data: {
                 items: [{
                     plan: plan.id


### PR DESCRIPTION
refs https://github.com/TryGhost/members.js/issues/29

- Allows passing metadata with custom info like member name to stripe's checkout session which can be used from webhook event on checkout completion
- Uses the metadata option in stripe checkout flow to add member's name on creation via anonymous checkout flow
- Allows clients like memebrs.js to pass member's info like name from checkout signup flow