### PR TITLE
Allow stripe promo codes

### DIFF
--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -122,6 +122,7 @@ module.exports = class StripePaymentProcessor {
             cancel_url: options.cancelUrl || this._checkoutCancelUrl,
             customer: customer ? customer.id : undefined,
             customer_email: customerEmail,
+            allow_promotion_codes: true,
             metadata,
             subscription_data: {
                 trial_from_plan: true,


### PR DESCRIPTION
This adds ability to use stripe (beta) coupon codes.

![image](https://user-images.githubusercontent.com/1919843/82720199-fe1d6700-9ca8-11ea-987f-59964a783bb5.png)

![image](https://user-images.githubusercontent.com/1919843/82720190-ea720080-9ca8-11ea-83b5-8f46b24ebec3.png)
