### PR TITLE
Refactor complimentary plans

### DIFF
--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -1,3 +1,4 @@
+const Stripe = require('stripe').default;
 const debug = require('ghost-ignition').debug('stripe');
 const _ = require('lodash');
 const {retrieve, list, create, update, del} = require('./api/stripeRequests');
@@ -30,9 +31,10 @@ module.exports = class StripePaymentProcessor {
     }
 
     async _configure(config) {
-        this._stripe = require('stripe')(config.secretKey);
-        this._stripe.setAppInfo(config.appInfo);
-        this._stripe.setApiVersion(STRIPE_API_VERSION);
+        this._stripe = new Stripe(config.secretKey, {
+            apiVersion: '2020-03-02',
+            appInfo: config.appInfo
+        });
         this._stripe.__TEST_MODE__ = config.secretKey.startsWith('sk_test_');
         this._public_token = config.publicKey;
         this._checkoutSuccessUrl = config.checkoutSuccessUrl;

--- a/packages/members-api/package.json
+++ b/packages/members-api/package.json
@@ -21,7 +21,8 @@
     "mocha": "6.2.2",
     "nock": "12.0.3",
     "should": "13.2.3",
-    "sinon": "7.5.0"
+    "sinon": "7.5.0",
+    "typescript": "^3.9.5"
   },
   "dependencies": {
     "@tryghost/magic-link": "^0.4.9",

--- a/packages/members-api/package.json
+++ b/packages/members-api/package.json
@@ -34,7 +34,7 @@
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.11",
     "node-jose": "^1.1.3",
-    "stripe": "^7.4.0"
+    "stripe": "^8.63.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3237,6 +3237,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^3.9.5:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,6 +164,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.47.tgz#5007b8866a2f9150de82335ca7e24dd1d59bdfb5"
   integrity sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A==
 
+"@types/node@>=8.1.0":
+  version "14.0.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.13.tgz#ee1128e881b874c371374c1f72201893616417c9"
+  integrity sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==
+
 "@types/nodemailer@6.4.0":
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.0.tgz#d8c039be3ed685c4719a026455555be82c124b74"
@@ -3063,11 +3068,12 @@ strip-json-comments@3.0.1, strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
-stripe@^7.4.0:
-  version "7.15.0"
-  resolved "https://registry.yarnpkg.com/stripe/-/stripe-7.15.0.tgz#03593caec169b698997c091b07d21da701eeee18"
-  integrity sha512-TmouNGv1rIU7cgw7iFKjdQueJSwYKdPRPBuO7eNjrRliZUnsf2bpJqYe+n6ByarUJr38KmhLheVUxDyRawByPQ==
+stripe@^8.63.0:
+  version "8.63.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-8.63.0.tgz#44926a492ebec0723c4a7d293fcaea130ada92ee"
+  integrity sha512-IjT4c9sPy/hNA4VKLRZq1+bUnL8V3nqCGSGnEA2ueCZi9CDS1ev8Q3t/6gh9lrgJ23ps+Z5MC29WLn4EZvIuBQ==
   dependencies:
+    "@types/node" ">=8.1.0"
     qs "^6.6.0"
 
 supports-color@6.0.0:


### PR DESCRIPTION
closes #168 

This updates the `setComplimentarySubscription` to use the Price's API to give members a 0 cost subscription. It also adds `complimentary: true` to the subscription metadata, and ensures the "plans name" is stored as "Complimentary" to reduce the changes needed in the Admin