### PR TITLE
Refactor webhook creation

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -97,7 +97,7 @@ module.exports = function MembersApi({
         getSubject
     });
 
-    async function sendEmailWithMagicLink({email, requestedType, payload, options = {forceEmailType: false}}){
+    async function sendEmailWithMagicLink({email, requestedType, payload, options = {forceEmailType: false}}) {
         if (options.forceEmailType) {
             return magicLinkService.sendMagicLink({email, payload, subject: email, type: requestedType});
         }
@@ -144,11 +144,11 @@ module.exports = function MembersApi({
         return getMemberIdentityData(email);
     }
 
-    async function getMemberIdentityData(email){
+    async function getMemberIdentityData(email) {
         return users.get({email});
     }
 
-    async function getMemberIdentityToken(email){
+    async function getMemberIdentityToken(email) {
         const member = await getMemberIdentityData(email);
         if (!member) {
             return null;

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -27,9 +27,11 @@ module.exports = function MembersApi({
         getHTML,
         getSubject
     },
-    memberStripeCustomerModel,
-    stripeCustomerSubscriptionModel,
-    memberModel,
+    models: {
+        StripeCustomer,
+        StripeCustomerSubscription,
+        Member
+    },
     logger
 }) {
     if (logger) {
@@ -37,10 +39,13 @@ module.exports = function MembersApi({
     }
 
     const {encodeIdentityToken, decodeToken} = Tokens({privateKey, publicKey, issuer});
-    const metadata = Metadata({memberStripeCustomerModel, stripeCustomerSubscriptionModel});
+    const metadata = Metadata({
+        StripeCustomer,
+        StripeCustomerSubscription
+    });
 
     async function hasActiveStripeSubscriptions() {
-        const firstActiveSubscription = await stripeCustomerSubscriptionModel.findOne({
+        const firstActiveSubscription = await StripeCustomerSubscription.findOne({
             status: 'active'
         });
 
@@ -48,7 +53,7 @@ module.exports = function MembersApi({
             return true;
         }
 
-        const firstTrialingSubscription = await stripeCustomerSubscriptionModel.findOne({
+        const firstTrialingSubscription = await StripeCustomerSubscription.findOne({
             status: 'trialing'
         });
 
@@ -111,7 +116,7 @@ module.exports = function MembersApi({
 
     const users = Users({
         stripe,
-        memberModel
+        Member
     });
 
     async function getMemberDataFromMagicLinkToken(token) {

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -28,6 +28,7 @@ module.exports = function MembersApi({
         getSubject
     },
     models: {
+        StripeWebhook,
         StripeCustomer,
         StripeCustomerSubscription,
         Member
@@ -40,6 +41,7 @@ module.exports = function MembersApi({
 
     const {encodeIdentityToken, decodeToken} = Tokens({privateKey, publicKey, issuer});
     const metadata = Metadata({
+        StripeWebhook,
         StripeCustomer,
         StripeCustomerSubscription
     });

--- a/packages/members-api/lib/metadata.js
+++ b/packages/members-api/lib/metadata.js
@@ -1,4 +1,5 @@
 module.exports = function ({
+    StripeWebhook,
     StripeCustomer,
     StripeCustomerSubscription
 }) {
@@ -16,6 +17,12 @@ module.exports = function ({
         if (metadata.subscription) {
             await StripeCustomerSubscription.upsert(metadata.subscription, {
                 subscription_id: metadata.subscription.subscription_id
+            });
+        }
+
+        if (metadata.webhook) {
+            await StripeWebhook.upsert(metadata.webhook, {
+                webhook_id: metadata.webhook.webhook_id
             });
         }
 

--- a/packages/members-api/lib/metadata.js
+++ b/packages/members-api/lib/metadata.js
@@ -1,54 +1,48 @@
-let MemberStripeCustomer;
-let StripeCustomerSubscription;
-
-async function setMetadata(module, metadata) {
-    if (module !== 'stripe') {
-        return;
-    }
-
-    if (metadata.customer) {
-        await MemberStripeCustomer.upsert(metadata.customer, {
-            customer_id: metadata.customer.customer_id
-        });
-    }
-
-    if (metadata.subscription) {
-        await StripeCustomerSubscription.upsert(metadata.subscription, {
-            subscription_id: metadata.subscription.subscription_id
-        });
-    }
-
-    return;
-}
-
-async function getMetadata(module, member) {
-    if (module !== 'stripe') {
-        return;
-    }
-
-    const customers = (await MemberStripeCustomer.findAll({
-        filter: `member_id:${member.id}`
-    })).toJSON();
-
-    const subscriptions = await customers.reduce(async (subscriptionsPromise, customer) => {
-        const customerSubscriptions = await StripeCustomerSubscription.findAll({
-            filter: `customer_id:${customer.customer_id}`
-        });
-        return (await subscriptionsPromise).concat(customerSubscriptions.toJSON());
-    }, []);
-
-    return {
-        customers: customers,
-        subscriptions: subscriptions
-    };
-}
-
 module.exports = function ({
-    memberStripeCustomerModel,
-    stripeCustomerSubscriptionModel
+    StripeCustomer,
+    StripeCustomerSubscription
 }) {
-    MemberStripeCustomer = memberStripeCustomerModel;
-    StripeCustomerSubscription = stripeCustomerSubscriptionModel;
+    async function setMetadata(module, metadata) {
+        if (module !== 'stripe') {
+            return;
+        }
+
+        if (metadata.customer) {
+            await StripeCustomer.upsert(metadata.customer, {
+                customer_id: metadata.customer.customer_id
+            });
+        }
+
+        if (metadata.subscription) {
+            await StripeCustomerSubscription.upsert(metadata.subscription, {
+                subscription_id: metadata.subscription.subscription_id
+            });
+        }
+
+        return;
+    }
+
+    async function getMetadata(module, member) {
+        if (module !== 'stripe') {
+            return;
+        }
+
+        const customers = (await StripeCustomer.findAll({
+            filter: `member_id:${member.id}`
+        })).toJSON();
+
+        const subscriptions = await customers.reduce(async (subscriptionsPromise, customer) => {
+            const customerSubscriptions = await StripeCustomerSubscription.findAll({
+                filter: `customer_id:${customer.customer_id}`
+            });
+            return (await subscriptionsPromise).concat(customerSubscriptions.toJSON());
+        }, []);
+
+        return {
+            customers: customers,
+            subscriptions: subscriptions
+        };
+    }
 
     return {
         setMetadata,

--- a/packages/members-api/lib/users.js
+++ b/packages/members-api/lib/users.js
@@ -2,60 +2,56 @@ const _ = require('lodash');
 const debug = require('ghost-ignition').debug('users');
 const common = require('./common');
 
-let Member;
-
-async function createMember({email, name, note, labels, geolocation}) {
-    const model = await Member.add({
-        email,
-        name,
-        note,
-        labels,
-        geolocation
-    });
-    const member = model.toJSON();
-    return member;
-}
-
-async function getMember(data, options = {}) {
-    if (!data.email && !data.id && !data.uuid) {
-        return null;
-    }
-    const model = await Member.findOne(data, options);
-    if (!model) {
-        return null;
-    }
-    const member = model.toJSON(options);
-    return member;
-}
-
-async function updateMember(data, options = {}) {
-    const attrs = _.pick(data, ['email', 'name', 'note', 'subscribed', 'geolocation']);
-
-    const model = await Member.edit(attrs, options);
-
-    const member = model.toJSON(options);
-    return member;
-}
-
-function deleteMember(options) {
-    options = options || {};
-    return Member.destroy(options);
-}
-
-function listMembers(options) {
-    return Member.findPage(options).then((models) => {
-        return {
-            members: models.data.map(model => model.toJSON(options)),
-            meta: models.meta
-        };
-    });
-}
-
 module.exports = function ({
     stripe,
-    memberModel
+    Member
 }) {
-    Member = memberModel;
+    async function createMember({email, name, note, labels, geolocation}) {
+        const model = await Member.add({
+            email,
+            name,
+            note,
+            labels,
+            geolocation
+        });
+        const member = model.toJSON();
+        return member;
+    }
+
+    async function getMember(data, options = {}) {
+        if (!data.email && !data.id && !data.uuid) {
+            return null;
+        }
+        const model = await Member.findOne(data, options);
+        if (!model) {
+            return null;
+        }
+        const member = model.toJSON(options);
+        return member;
+    }
+
+    async function updateMember(data, options = {}) {
+        const attrs = _.pick(data, ['email', 'name', 'note', 'subscribed', 'geolocation']);
+
+        const model = await Member.edit(attrs, options);
+
+        const member = model.toJSON(options);
+        return member;
+    }
+
+    function deleteMember(options) {
+        options = options || {};
+        return Member.destroy(options);
+    }
+
+    function listMembers(options) {
+        return Member.findPage(options).then((models) => {
+            return {
+                members: models.data.map(model => model.toJSON(options)),
+                meta: models.meta
+            };
+        });
+    }
 
     async function getStripeSubscriptions(member) {
         if (!stripe) {

--- a/packages/members-api/package.json
+++ b/packages/members-api/package.json
@@ -17,6 +17,7 @@
     "gateway"
   ],
   "devDependencies": {
+    "@types/stripe": "^7.13.24",
     "jsdom": "15.2.1",
     "mocha": "6.2.2",
     "nock": "12.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,6 +184,13 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
+"@types/stripe@^7.13.24":
+  version "7.13.24"
+  resolved "https://registry.yarnpkg.com/@types/stripe/-/stripe-7.13.24.tgz#a82416d949bad90bc283db399958fa0c3cbe41a3"
+  integrity sha512-jlY9nvZMHSikta0udPubW5HcIl3C9waWPHqAi2oCL9dn91rwJLfKp/A9b7Trif+YTOv0StACk1gGLyBSgXQNmA==
+  dependencies:
+    "@types/node" "*"
+
 abab@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"


### PR DESCRIPTION
no-issue

This refactors the webhook creation to reuse an exisiting webhook when possible. This will stop an entire class of errors & bugs which were due to the webhook secret being stored in memory & the webhook endpoints being deleted.