### PR TITLE
Added Idempotency-Key header to create requests

### DIFF
--- a/packages/members-api/lib/stripe/api/createDeterministicApi.js
+++ b/packages/members-api/lib/stripe/api/createDeterministicApi.js
@@ -42,7 +42,8 @@ function createCreator(resource, getAttrs) {
         return stripeCreate(
             stripe,
             resource,
-            Object.assign(getAttrs(object, ...rest), {id})
+            Object.assign(getAttrs(object, ...rest), {id}),
+            {idempotencyKey: id}
         );
     };
 }

--- a/packages/members-api/lib/stripe/api/stripeRequests.js
+++ b/packages/members-api/lib/stripe/api/stripeRequests.js
@@ -11,9 +11,9 @@ const list = createStripeRequest(function (stripe, resource, options) {
     return stripe[resource].list(options);
 });
 
-const create = createStripeRequest(function (stripe, resource, object) {
+const create = createStripeRequest(function (stripe, resource, object, options = {}) {
     debug(`create ${resource} ${JSON.stringify(object)}`);
-    return stripe[resource].create(object);
+    return stripe[resource].create(object, Object.assign({}, options, {timeout: 80000}));
 });
 
 const update = createStripeRequest(function (stripe, resource, id, object) {

--- a/packages/members-api/test/unit/lib/stripe.test.js
+++ b/packages/members-api/test/unit/lib/stripe.test.js
@@ -1,0 +1,59 @@
+const http = require('http');
+const util = require('util');
+const should = require('should');
+const Stripe = require('stripe');
+const stripeAPI = require('../../../lib/stripe/api');
+
+const config = {
+    publishableKey: 'pk_test_00000000000000000000',
+    secretKey: 'pk_test_00000000000000000000',
+    apiVersion: '2019-09-09',
+    webhookSecret: 'whsec_00000000000000000'
+};
+
+async function setupStripeServer(stripe) {
+    const server = http.createServer();
+    const listen = util.promisify(server.listen.bind(server));
+
+    await listen(0, '127.0.0.1');
+
+    const {address: host, port} = server.address();
+    stripe.setProtocol('http');
+    stripe.setHost(host);
+    stripe.setPort(port);
+
+    return server;
+}
+
+describe('Plans API', function () {
+    it('Uses an idempotency key when creating plans', async function () {
+        const stripe = new Stripe(config.secretKey, config.apiVersion);
+
+        const server = await setupStripeServer(stripe);
+
+        server.on('request', function (req, res) {
+            res.writeHead(200);
+            res.end('{}');
+
+            should.exist(req.headers['idempotency-key'], 'Request should have had an Idempotency-Key header');
+            should.equal(req.headers['idempotency-key'], 'PLAN_ID', 'Should have used the plan id as the Idempotency-Key header value');
+
+            req.connection.destroy();
+        });
+
+        try {
+            await stripeAPI.plans.create(stripe, 'PLAN_ID', {
+                name: 'plan',
+                amount: 100,
+                currency: 'usd',
+                interval: 'year'
+            }, {
+                product: {
+                    id: 'PRODUCT_ID'
+                }
+            });
+        } finally {
+            server.close();
+        }
+    });
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12065

This will ensure that the deterministic api really is deterministic, and
it no longer errors when multiple instances are run in parallel.

We've also added a test to check the header is sent.