### PR TITLE
Caught & handled 'resource_already_exists' errors

### DIFF
--- a/packages/members-api/lib/stripe/api/createDeterministicApi.js
+++ b/packages/members-api/lib/stripe/api/createDeterministicApi.js
@@ -43,7 +43,12 @@ function createCreator(resource, getAttrs) {
             stripe,
             resource,
             Object.assign(getAttrs(object, ...rest), {id})
-        );
+        ).catch((err) => {
+            if (err.code !== 'resource_already_exists') {
+                throw err;
+            }
+            return stripeRetrieve(stripe, resource, id);
+        });
     };
 }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12065

This protects us against multiple instances of the members-api being
started simultaneously and race conditions where inbetween the initial
"GET" of a plan which returns empty, and the "POST" of a plan to create
it, another instance has already created it.