### PR TITLE
Updated webhooks cleanup to handle all older webhooks

### DIFF
--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -90,11 +90,11 @@ module.exports = class StripePaymentProcessor {
                 limit: 100
             });
 
-            const webhookToCleanup = webhooks.data.find((webhook) => {
-                return webhook.url === config.webhookHandlerUrl.slice(0, -1);
+            const webhooksToCleanup = webhooks.data.filter((webhook) => {
+                return webhook.url === config.webhookHandlerUrl.slice(0, -1) || webhook.url === config.webhookHandlerUrl;
             });
 
-            if (webhookToCleanup) {
+            for (const webhookToCleanup of webhooksToCleanup) {
                 await del(this._stripe, 'webhookEndpoints', webhookToCleanup.id);
             }
         } catch (err) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12074
refs https://github.com/TryGhost/Members/pull/18

Some sites may have had duplicate webhooks created due to a race
condition. This updates the members-api to cleanup _all_ webhooks before
starting, allowing it to create webhooks on a fresh slate, and removing
possible causes of 401 errors due to incorrect webhook secrets.