### PR TITLE
Updates for handling deletion of Members in Ghost

### DIFF
--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -266,8 +266,13 @@ module.exports = class StripePaymentProcessor {
         });
 
         for (const subscription of activeSubscriptions) {
-            const updatedSubscription = await del(this._stripe, 'subscriptions', subscription.id);
-            await this._updateSubscription(updatedSubscription);
+            try {
+                const updatedSubscription = await del(this._stripe, 'subscriptions', subscription.id);
+                await this._updateSubscription(updatedSubscription);
+            } catch (err) {
+                this.logging.error(`There was an error cancelling subscription ${subscription.id}`);
+                this.logging.error(err);
+            }
         }
 
         return true;

--- a/packages/members-api/lib/users.js
+++ b/packages/members-api/lib/users.js
@@ -61,7 +61,7 @@ module.exports = function ({
         return await stripe.getActiveSubscriptions(member);
     }
 
-    async function destroyStripeSubscriptions(member) {
+    async function cancelStripeSubscriptions(member) {
         if (stripe) {
             await stripe.cancelAllSubscriptions(member);
         }
@@ -119,7 +119,7 @@ module.exports = function ({
             return;
         }
 
-        await destroyStripeSubscriptions(member);
+        await cancelStripeSubscriptions(member);
 
         return deleteMember(data);
     }
@@ -190,7 +190,7 @@ module.exports = function ({
         getStripeSubscriptions,
         setComplimentarySubscription,
         cancelComplimentarySubscription,
-        destroyStripeSubscriptions,
+        cancelStripeSubscriptions,
         getStripeCustomer,
         linkStripeCustomer
     };


### PR DESCRIPTION
no-issue

This updates the exposed method used to cancel stripe subscriptions name to `cancelStripeSubscriptions`, from `destroyStripeSubscriptions` to avoid confusion with the database/model layer.

We also add handling to errors when deleting/cancelling Stripe subscriptions so that any issues (such as the subscription already being cancelled) are logged, but do not disrupt the flow