### PR TITLE
Ensured that we do not insert orphaned rows

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -41,6 +41,7 @@ module.exports = function MembersApi({
 
     const {encodeIdentityToken, decodeToken} = Tokens({privateKey, publicKey, issuer});
     const metadata = Metadata({
+        Member,
         StripeWebhook,
         StripeCustomer,
         StripeCustomerSubscription

--- a/packages/members-api/lib/metadata.js
+++ b/packages/members-api/lib/metadata.js
@@ -1,4 +1,5 @@
 module.exports = function ({
+    Member,
     StripeWebhook,
     StripeCustomer,
     StripeCustomerSubscription
@@ -9,15 +10,26 @@ module.exports = function ({
         }
 
         if (metadata.customer) {
-            await StripeCustomer.upsert(metadata.customer, {
-                customer_id: metadata.customer.customer_id
+            const member = await Member.findOne({
+                id: metadata.customer.member_id
             });
+
+            if (member) {
+                await StripeCustomer.upsert(metadata.customer, {
+                    customer_id: metadata.customer.customer_id
+                });
+            }
         }
 
         if (metadata.subscription) {
-            await StripeCustomerSubscription.upsert(metadata.subscription, {
-                subscription_id: metadata.subscription.subscription_id
+            const customer = await StripeCustomer.findOne({
+                customer_id: metadata.subscription.customer_id
             });
+            if (customer) {
+                await StripeCustomerSubscription.upsert(metadata.subscription, {
+                    subscription_id: metadata.subscription.subscription_id
+                });
+            }
         }
 
         if (metadata.webhook) {


### PR DESCRIPTION
no-issue

Previously we would blindly put subscriptions into the database when we
received a webhook, which could result in orphaned rows that were not
linked to a customer (and by extension a member)

This updates the logic so that we will only add subscriptions if we have
a record of their customer.

Customers are only added during a checkout.session.completed webhook, at
which point a member is guarunteed, but for formailty and safety against
changes in the flow, the logic has been applied to inserting customers
too.