### PR TITLE
Added ability to recognize if a coupon was sent in 

### DIFF
--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -208,8 +208,12 @@ module.exports = class StripePaymentProcessor {
                     plan: plan.id
                 }]
             }
+        };
+        
+        if (metadata && metadata.coupon) {
+            payload.subscription_data.coupon = metadata.coupon;
         }
-        if(metadata && metadata.coupon) payload.subscription_data.coupon = metadata.coupon;
+        
         const session = await this._stripe.checkout.sessions.create(payload);
 
         return {

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -195,7 +195,7 @@ module.exports = class StripePaymentProcessor {
         const plan = this._plans.find(plan => plan.nickname === planName);
         const customerEmail = (!customer && options.customerEmail) ? options.customerEmail : undefined;
         const metadata = options.metadata || undefined;
-        const session = await this._stripe.checkout.sessions.create({
+        const payload = {
             payment_method_types: ['card'],
             success_url: options.successUrl || this._checkoutSuccessUrl,
             cancel_url: options.cancelUrl || this._checkoutCancelUrl,
@@ -208,7 +208,9 @@ module.exports = class StripePaymentProcessor {
                     plan: plan.id
                 }]
             }
-        });
+        }
+        if(metadata && metadata.coupon) payload.subscription_data.coupon = metadata.coupon;
+        const session = await this._stripe.checkout.sessions.create(payload);
 
         return {
             sessionId: session.id,


### PR DESCRIPTION
Hi friends - you can send a coupon through to Stripe during session create, which is what I've setup here. I did two things: 

 - I refactored the session data into a `payload` variable
 - I added a check to see if `metadata` existed AND if it had a `coupon` code attached. If it did, then that code is sent in to the stripe checkout session.

This small change allows theme developers to add a coupon input to the checkout page, adding a `metadata` key with the `coupon` key set. This will return a 400 if the coupon is invalid, which the theme dev would need to catch - that would report back that the coupon is invalid.

You can see more of the discussion here, as well as the code: https://forum.ghost.org/t/discount-codes-for-stripe-pls/16130/9 