### PR TITLE
Add support for promo/coupon codes in Stripe Checkout

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -75,7 +75,7 @@ module.exports = function MembersApi({
             return metadata.setMetadata('stripe', data);
         }
     };
-    const stripe = paymentConfig.stripe ? new StripePaymentProcessor(paymentConfig.stripe, stripeStorage, common.logging, paymentConfig.enableStripePromoCodes) : null;
+    const stripe = paymentConfig.stripe ? new StripePaymentProcessor(paymentConfig.stripe, stripeStorage, common.logging) : null;
 
     async function ensureStripe(_req, res, next) {
         if (!stripe) {

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -75,7 +75,7 @@ module.exports = function MembersApi({
             return metadata.setMetadata('stripe', data);
         }
     };
-    const stripe = paymentConfig.stripe ? new StripePaymentProcessor(paymentConfig.stripe, stripeStorage, common.logging) : null;
+    const stripe = paymentConfig.stripe ? new StripePaymentProcessor(paymentConfig.stripe, stripeStorage, common.logging, paymentConfig.enableStripePromoCodes) : null;
 
     async function ensureStripe(_req, res, next) {
         if (!stripe) {

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -201,6 +201,7 @@ module.exports = class StripePaymentProcessor {
             cancel_url: options.cancelUrl || this._checkoutCancelUrl,
             customer: customer ? customer.id : undefined,
             customer_email: customerEmail,
+            allow_promotion_codes: true,
             metadata,
             subscription_data: {
                 trial_from_plan: true,

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -15,10 +15,9 @@ const CURRENCY_SYMBOLS = {
 };
 
 module.exports = class StripePaymentProcessor {
-    constructor(config, storage, logging, allowPromotionCodes = false) {
+    constructor(config, storage, logging) {
         this.logging = logging;
         this.storage = storage;
-        this.allowPromotionCodes = allowPromotionCodes;
         this._ready = new Promise((resolve, reject) => {
             this._resolveReady = resolve;
             this._rejectReady = reject;
@@ -40,6 +39,7 @@ module.exports = class StripePaymentProcessor {
         this._checkoutCancelUrl = config.checkoutCancelUrl;
         this._billingSuccessUrl = config.billingSuccessUrl;
         this._billingCancelUrl = config.billingCancelUrl;
+        this._enablePromoCodes = config.enablePromoCodes;
 
         try {
             this._product = await api.products.ensure(this._stripe, config.product);
@@ -202,7 +202,7 @@ module.exports = class StripePaymentProcessor {
             cancel_url: options.cancelUrl || this._checkoutCancelUrl,
             customer: customer ? customer.id : undefined,
             customer_email: customerEmail,
-            allow_promotion_codes: this.allowPromotionCodes,
+            allow_promotion_codes: this._enablePromoCodes,
             metadata,
             subscription_data: {
                 trial_from_plan: true,

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -15,9 +15,10 @@ const CURRENCY_SYMBOLS = {
 };
 
 module.exports = class StripePaymentProcessor {
-    constructor(config, storage, logging) {
+    constructor(config, storage, logging, allowPromotionCodes = false) {
         this.logging = logging;
         this.storage = storage;
+        this.allowPromotionCodes = allowPromotionCodes;
         this._ready = new Promise((resolve, reject) => {
             this._resolveReady = resolve;
             this._rejectReady = reject;
@@ -201,7 +202,7 @@ module.exports = class StripePaymentProcessor {
             cancel_url: options.cancelUrl || this._checkoutCancelUrl,
             customer: customer ? customer.id : undefined,
             customer_email: customerEmail,
-            allow_promotion_codes: true,
+            allow_promotion_codes: this.allowPromotionCodes,
             metadata,
             subscription_data: {
                 trial_from_plan: true,


### PR DESCRIPTION
This PR adds support for Stripe's newly-added [promo code feature in Stripe Checkout](https://twitter.com/stripe/status/1291441519585406976). I've defaulted this value to `true` because it's fairly unobtrusive in the UI, and can safely be ignored if a new member subscribes and doesn't have a coupon to use.

The Stripe documentation on adding customer-facing promotion codes:
https://stripe.com/docs/payments/checkout/set-up-a-subscription#coupons

I've tested this with a local installation and found that it adds the promo code UI as expected (see included screenshots with PR). I then completed the checkout process with a coupon and found that it successfully applied the coupon - woohoo!

<details>
  <summary>📷 Screenshots of the new coupon UI when redirected to Stripe Checkout</summary>
  <img width="1200" alt="Screen Shot 2020-08-07 at 12 01 33 AM" src="https://user-images.githubusercontent.com/922353/89610839-390f4f80-d841-11ea-81a1-ae5d473d70fd.png">
  <img width="1200" alt="Screen Shot 2020-08-07 at 12 01 44 AM" src="https://user-images.githubusercontent.com/922353/89610842-3ad91300-d841-11ea-976b-c8d7cf086814.png">
</details>

<details>
  <summary>📷 Screenshots of the coupon being persisted into the invoice and Stripe customer after checking out</summary>
  <img width="1144" alt="Screen Shot 2020-08-06 at 11 56 54 PM" src="https://user-images.githubusercontent.com/922353/89610964-812e7200-d841-11ea-9db2-3bf7e0656b7d.png">
  <img width="1125" alt="Screen Shot 2020-08-06 at 11 56 37 PM" src="https://user-images.githubusercontent.com/922353/89610959-8095db80-d841-11ea-9aa5-b47bf61cec57.png">
</details>

One thing worth noting: it doesn't appear that the coupon information shows up in the Members section in Ghost admin, just the pricing (e.g. $50/yearly, but no mention if I use a 100% coupon). Not sure how to solve that one, but being able to view the subscription in Stripe from the link on the member page seems like an acceptable compromise!

BTW, this is the first PR I've submitted to the extended Ghost universe of source code so happy to accept any changes or if there's a different way this should be done that feels better long-term, you're totally OK to close this :) just wanted to explore if I could get it working, and the resulting change was surprisingly straightforward!