### PR TITLE
Updated members-api to use models internally and expose them from the users API

### DIFF
--- a/packages/members-api/lib/metadata.js
+++ b/packages/members-api/lib/metadata.js
@@ -46,16 +46,16 @@ module.exports = function ({
             return;
         }
 
-        const customers = (await StripeCustomer.findAll({
-            filter: `member_id:${member.id}`
-        })).toJSON();
+        if (!member.relations.stripeCustomers) {
+            await member.load(['stripeCustomers']);
+        }
 
-        const subscriptions = await customers.reduce(async (subscriptionsPromise, customer) => {
-            const customerSubscriptions = await StripeCustomerSubscription.findAll({
-                filter: `customer_id:${customer.customer_id}`
-            });
-            return (await subscriptionsPromise).concat(customerSubscriptions.toJSON());
-        }, []);
+        if (!member.relations.stripeSubscriptions) {
+            await member.load(['stripeSubscriptions', 'stripeSubscriptions.customer']);
+        }
+
+        const customers = member.related('stripeCustomers').toJSON();
+        const subscriptions = member.related('stripeSubscriptions').toJSON();
 
         return {
             customers: customers,

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -244,7 +244,7 @@ module.exports = class StripePaymentProcessor {
             payment_method_types: ['card'],
             success_url: options.successUrl || this._billingSuccessUrl,
             cancel_url: options.cancelUrl || this._billingCancelUrl,
-            customer_email: member.email,
+            customer_email: member.get('email'),
             setup_intent_data: {
                 metadata: {
                     customer_id: customer.id
@@ -296,35 +296,7 @@ module.exports = class StripePaymentProcessor {
     async getSubscriptions(member) {
         const metadata = await this.storage.get(member);
 
-        const customers = metadata.customers.reduce((customers, customer) => {
-            return Object.assign(customers, {
-                [customer.customer_id]: {
-                    id: customer.customer_id,
-                    name: customer.name,
-                    email: customer.email
-                }
-            });
-        }, {});
-
-        return metadata.subscriptions.map((subscription) => {
-            return {
-                id: subscription.subscription_id,
-                customer: customers[subscription.customer_id],
-                plan: {
-                    id: subscription.plan_id,
-                    nickname: subscription.plan_nickname,
-                    interval: subscription.plan_interval,
-                    amount: subscription.plan_amount,
-                    currency: String.prototype.toUpperCase.call(subscription.plan_currency),
-                    currency_symbol: CURRENCY_SYMBOLS[subscription.plan_currency]
-                },
-                status: subscription.status,
-                start_date: subscription.start_date,
-                default_payment_card_last4: subscription.default_payment_card_last4,
-                cancel_at_period_end: subscription.cancel_at_period_end,
-                current_period_end: subscription.current_period_end
-            };
-        });
+        return metadata.subscriptions;
     }
 
     async setComplimentarySubscription(member) {
@@ -438,11 +410,11 @@ module.exports = class StripePaymentProcessor {
     }
 
     async _updateCustomer(member, customer) {
-        debug(`Attaching customer to member ${member.email} ${customer.id}`);
+        debug(`Attaching customer to member ${member.get('email')} ${customer.id}`);
         await this.storage.set({
             customer: {
                 customer_id: customer.id,
-                member_id: member.id,
+                member_id: member.get('id'),
                 name: customer.name,
                 email: customer.email
             }
@@ -500,9 +472,9 @@ module.exports = class StripePaymentProcessor {
             }
         }
 
-        debug(`Creating customer for member ${member.email}`);
+        debug(`Creating customer for member ${member.get('email')}`);
         const customer = await create(this._stripe, 'customers', {
-            email: member.email
+            email: member.get('email')
         });
 
         await this._updateCustomer(member, customer);

--- a/packages/members-api/lib/users.js
+++ b/packages/members-api/lib/users.js
@@ -1,184 +1,73 @@
 const _ = require('lodash');
 const debug = require('ghost-ignition').debug('users');
-const common = require('./common');
 
 module.exports = function ({
     stripe,
     Member
 }) {
-    async function createMember({email, name, note, labels, geolocation}) {
-        const model = await Member.add({
+    async function get(data, options) {
+        debug(`get id:${data.id} email:${data.email}`);
+        return Member.findOne(data, options);
+    }
+
+    async function destroy(data, options) {
+        debug(`destroy id:${data.id} email:${data.email}`);
+        const member = await Member.findOne(data, options);
+        if (!member) {
+            return;
+        }
+
+        if (stripe && options.cancelStripeSubscriptions) {
+            await stripe.cancelStripeSubscriptions(member);
+        }
+
+        return Member.destroy({
+            id: data.id
+        }, options);
+    }
+
+    async function update(data, options) {
+        debug(`update id:${options.id}`);
+        return Member.edit(_.pick(data, [
+            'email',
+            'name',
+            'note',
+            'labels',
+            'geolocation'
+        ]), options);
+    }
+
+    async function list(options = {}) {
+        return Member.findPage(options);
+    }
+
+    async function create({email, name, note, labels, geolocation}, options) {
+        debug(`create email:${email}`);
+
+        /** Member.add model method expects label object array*/
+        if (labels) {
+            labels.forEach((label, index) => {
+                if (_.isString(label)) {
+                    labels[index] = {name: label};
+                }
+            });
+        }
+
+        return Member.add({
             email,
             name,
             note,
             labels,
             geolocation
-        });
-        const member = model.toJSON();
-        return member;
+        }, options);
     }
 
-    async function getMember(data, options = {}) {
-        if (!data.email && !data.id && !data.uuid) {
-            return null;
-        }
-        const model = await Member.findOne(data, options);
-        if (!model) {
-            return null;
-        }
-        const member = model.toJSON(options);
-        return member;
-    }
-
-    async function updateMember(data, options = {}) {
-        const attrs = _.pick(data, ['email', 'name', 'note', 'subscribed', 'geolocation']);
-
-        const model = await Member.edit(attrs, options);
-
-        const member = model.toJSON(options);
-        return member;
-    }
-
-    function deleteMember(options) {
-        options = options || {};
-        return Member.destroy(options);
-    }
-
-    function listMembers(options) {
-        return Member.findPage(options).then((models) => {
-            return {
-                members: models.data.map(model => model.toJSON(options)),
-                meta: models.meta
-            };
-        });
-    }
-
-    async function getStripeSubscriptions(member) {
-        if (!stripe) {
-            return [];
-        }
-
-        return await stripe.getActiveSubscriptions(member);
-    }
-
-    async function cancelStripeSubscriptions(member) {
-        if (stripe) {
-            await stripe.cancelAllSubscriptions(member);
-        }
-    }
-
-    async function setComplimentarySubscription(member) {
-        if (stripe) {
-            await stripe.setComplimentarySubscription(member);
-        }
-    }
-
-    async function cancelComplimentarySubscription(member) {
-        if (stripe) {
-            await stripe.cancelComplimentarySubscription(member);
-        }
-    }
-
-    async function linkStripeCustomer(id, member) {
-        if (stripe) {
-            await stripe.linkStripeCustomer(id, member);
-        }
-    }
-
-    async function getStripeCustomer(id) {
-        if (stripe) {
-            return await stripe.getStripeCustomer(id);
-        }
-    }
-
-    async function get(data, options) {
-        debug(`get id:${data.id} email:${data.email}`);
-        const member = await getMember(data, options);
-        if (!member) {
-            return member;
-        }
-
-        try {
-            const subscriptions = await getStripeSubscriptions(member);
-
-            return Object.assign(member, {
-                stripe: {
-                    subscriptions
-                }
-            });
-        } catch (err) {
-            common.logging.error(err);
-            return null;
-        }
-    }
-
-    async function destroy(data, options) {
-        debug(`destroy id:${data.id} email:${data.email}`);
-        const member = await getMember(data, options);
-        if (!member) {
-            return;
-        }
-
-        await cancelStripeSubscriptions(member);
-
-        return deleteMember(data);
-    }
-
-    async function update(data, options) {
-        debug(`update id:${options.id}`);
-
-        const member = await updateMember(data, options);
-        if (!member) {
-            return member;
-        }
-
-        try {
-            const subscriptions = await getStripeSubscriptions(member);
-
-            return Object.assign(member, {
-                stripe: {
-                    subscriptions
-                }
-            });
-        } catch (err) {
-            common.logging.error(err);
-            return null;
-        }
-    }
-
-    async function list(options) {
-        const {meta, members} = await listMembers(options);
-
-        const membersWithSubscriptions = await Promise.all(members.map(async function (member) {
-            const subscriptions = await getStripeSubscriptions(member);
-
-            return Object.assign(member, {
-                stripe: {
-                    subscriptions
-                }
-            });
-        }));
-
-        return {
-            meta,
-            members: membersWithSubscriptions
+    function safeStripe(methodName) {
+        return async function (...args) {
+            if (stripe) {
+                return await stripe[methodName](...args);
+            }
         };
-    }
-
-    async function create(data) {
-        debug(`create email:${data.email}`);
-
-        /** Member.add model method expects label object array*/
-        if (data.labels) {
-            data.labels.forEach((label, index) => {
-                if (_.isString(label)) {
-                    data.labels[index] = {name: label};
-                }
-            });
-        }
-
-        const member = await createMember(data);
-        return member;
     }
 
     return {
@@ -187,11 +76,10 @@ module.exports = function ({
         list,
         get,
         destroy,
-        getStripeSubscriptions,
-        setComplimentarySubscription,
-        cancelComplimentarySubscription,
-        cancelStripeSubscriptions,
-        getStripeCustomer,
-        linkStripeCustomer
+        setComplimentarySubscription: safeStripe('setComplimentarySubscription'),
+        cancelComplimentarySubscription: safeStripe('cancelComplimentarySubscription'),
+        cancelStripeSubscriptions: safeStripe('cancelComplimentarySubscription'),
+        getStripeCustomer: safeStripe('getStripeCustomer'),
+        linkStripeCustomer: safeStripe('linkStripeCustomer')
     };
 };


### PR DESCRIPTION
no-issue

Converting models to JSON is expensive and has forced "hot" code in Ghost core to avoid using the methods exposed by members-api in favour of handrolled model access so that it can be more performant.

These changes will allow us to consolidate all member queries to use the members-api, giving us a central place to fine tune and optimise any queries