### PR TITLE
Updates for bulk importer

### DIFF
--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -223,10 +223,6 @@ module.exports = class StripePaymentProcessor {
         return customer;
     }
 
-    async getStripeCustomer(id) {
-        return await retrieve(this._stripe, 'customers', id);
-    }
-
     async createCheckoutSetupSession(member, options) {
         const customer = await this._customerForMemberCheckoutSession(member);
 

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -464,7 +464,7 @@ module.exports = class StripePaymentProcessor {
         }
 
         debug(`Creating customer for member ${member.get('email')}`);
-        const customer = await create(this._stripe, 'customers', {
+        const customer = await this.createCustomer({
             email: member.get('email')
         });
 
@@ -475,6 +475,10 @@ module.exports = class StripePaymentProcessor {
 
     async getSetupIntent(id, options) {
         return retrieve(this._stripe, 'setupIntents', id, options);
+    }
+
+    async createCustomer(options) {
+        return create(this._stripe, 'customers', options);
     }
 
     async getCustomer(id, options) {

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -13,6 +13,10 @@ module.exports = class StripePaymentProcessor {
             this._resolveReady = resolve;
             this._rejectReady = reject;
         });
+        /**
+         * @type Array<import('stripe').plans.IPlan>
+         */
+        this._plans = [];
         this._configure(config);
     }
 
@@ -39,10 +43,6 @@ module.exports = class StripePaymentProcessor {
             return this._rejectReady(err);
         }
 
-        /**
-         * @type Array<import('stripe').plans.IPlan>
-         */
-        this._plans = [];
         for (const planSpec of config.plans) {
             try {
                 const plan = await api.plans.ensure(this._stripe, planSpec, this._product);

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -290,6 +290,26 @@ module.exports = class StripePaymentProcessor {
         return metadata.subscriptions;
     }
 
+    async createComplimentarySubscription(customer) {
+        const monthlyPlan = this._plans.find(plan => plan.interval === 'month');
+        if (!monthlyPlan) {
+            throw new Error('Could not find monthly plan');
+        }
+        const complimentaryCurrency = monthlyPlan.currency.toLowerCase();
+        const complimentaryPlan = this._plans.find(plan => plan.nickname === 'Complimentary' && plan.currency === complimentaryCurrency);
+
+        if (!complimentaryPlan) {
+            throw new Error('Could not find complimentaryPlan');
+        }
+
+        return create(this._stripe, 'subscriptions', {
+            customer: customer.id,
+            items: [{
+                plan: complimentaryPlan.id
+            }]
+        });
+    }
+
     async setComplimentarySubscription(member) {
         const subscriptions = await this.getActiveSubscriptions(member);
 

--- a/packages/members-api/lib/users.js
+++ b/packages/members-api/lib/users.js
@@ -97,6 +97,8 @@ module.exports = function ({
         cancelComplimentarySubscription: safeStripe('cancelComplimentarySubscription'),
         cancelStripeSubscriptions: safeStripe('cancelComplimentarySubscription'),
         getStripeCustomer: safeStripe('getCustomer'),
+        createStripeCustomer: safeStripe('createCustomer'),
+        createComplimentarySubscription: safeStripe('createComplimentarySubscription'),
         linkStripeCustomer: safeStripe('linkStripeCustomer'),
         linkStripeCustomerById
     };

--- a/packages/members-api/lib/users.js
+++ b/packages/members-api/lib/users.js
@@ -96,7 +96,7 @@ module.exports = function ({
         setComplimentarySubscriptionById,
         cancelComplimentarySubscription: safeStripe('cancelComplimentarySubscription'),
         cancelStripeSubscriptions: safeStripe('cancelComplimentarySubscription'),
-        getStripeCustomer: safeStripe('getStripeCustomer'),
+        getStripeCustomer: safeStripe('getCustomer'),
         linkStripeCustomer: safeStripe('linkStripeCustomer'),
         linkStripeCustomerById
     };

--- a/packages/members-api/package.json
+++ b/packages/members-api/package.json
@@ -33,6 +33,7 @@
     "ghost-ignition": "4.2.2",
     "got": "^9.6.0",
     "jsonwebtoken": "^8.5.1",
+    "leaky-bucket": "2.2.0",
     "lodash": "^4.17.11",
     "node-jose": "^1.1.3",
     "stripe": "^7.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,14 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@distributed-systems/callsite@^1.1.0", "@distributed-systems/callsite@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@distributed-systems/callsite/-/callsite-1.1.1.tgz#56a9e1a1d16ae6264ea3f51eea3782848fc27a88"
+  integrity sha512-YSA3kWjClnLmFKNpdQCZlMQoWI4N6KpR/T4MaREEQczaehcagsVorT3YDV17KR6zuJXDs7f+kkSt1o/D6SufAQ==
+  dependencies:
+    ee-log "^3.0.0"
+    section-tests "^1.3.0"
+
 "@ember-data/rfc395-data@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
@@ -289,6 +297,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -311,6 +324,11 @@ anymatch@~3.1.1:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+app-root-path@^2.1.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.2.1.tgz#d0df4a682ee408273583d43f6f79e9892624bc9a"
+  integrity sha512-91IFKeKk7FjfmezPKkwtaRvSpnUc4gDwPAjA1YZ9Gn0q0PPeW+vbeUsZuyDwjI7+QTHhcLen2v25fi/AmhvbJA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -545,7 +563,18 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
+chalk@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
+  dependencies:
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
+
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -883,10 +912,43 @@ ecdsa-sig-formatter@1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
+ee-argv@0.1.x:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/ee-argv/-/ee-argv-0.1.4.tgz#77f459daf980f11d2c6f8e28a21abb88020168ab"
+  integrity sha1-d/RZ2vmA8R0sb44oohq7iAIBaKs=
+
+ee-class@1.x, ee-class@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ee-class/-/ee-class-1.4.0.tgz#2903f622ee1fe40cd8ba989d7ea239a31bd5e255"
+  integrity sha1-KQP2Iu4f5AzYupidfqI5oxvV4lU=
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+ee-log@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ee-log/-/ee-log-1.1.0.tgz#31b1ef1bda720ccec29523df05482428ceea3582"
+  integrity sha1-MbHvG9pyDM7ClSPfBUgkKM7qNYI=
+  dependencies:
+    ee-class "1.x"
+    ee-types "2.x"
+
+ee-log@^3.0.0, ee-log@^3.0.5:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/ee-log/-/ee-log-3.0.9.tgz#a9ab95414f3eaefab0573ea18fc8dfb1797e8670"
+  integrity sha512-SdIG4RfLPuv8N2cIJWgaW00V6xZsrEZJq/OcKl1SkyeNYYGeQKOUS0JzyvTAiPvy8bLCLSLYwtx37ZUQPe1xJg==
+  dependencies:
+    "@distributed-systems/callsite" "^1.1.1"
+    logd-console-output "^1.2.1"
+
+ee-types@2.x, ee-types@^2.1.4, ee-types@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ee-types/-/ee-types-2.2.1.tgz#1be9b6704ffa200cb0003ece72dca8037c1dd1de"
+  integrity sha512-ZgShE8RXsE+DFAddCmduKwUwoNLZd7Ik6yv6LFEUDfz/6k2s6rTvABQS8dO2EibJpYFWREOx/ealtwuTUXeeYg==
+  dependencies:
+    ee-class "^1.4.0"
 
 ember-rfc176-data@^0.3.12:
   version "0.3.13"
@@ -969,7 +1031,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -1417,7 +1479,7 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.6, glob@^7.1.3:
+glob@7.1.6, glob@^7.1.2, glob@^7.1.3:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -1486,6 +1548,13 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.5.5"
     har-schema "^2.0.0"
+
+has-ansi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
+  dependencies:
+    ansi-regex "^2.0.0"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -1938,6 +2007,16 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+leaky-bucket@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/leaky-bucket/-/leaky-bucket-2.2.0.tgz#d37da29a45f64528c86b6882d2b5e1594588e2de"
+  integrity sha512-87qsyt18gLVb+uB+zVz1zSi3yl6UJD5AoKINNOg3PBfqMis1FGgfOTi6hLkw7lJYZ3Gawf/BLj76WhDqsT0eZA==
+  dependencies:
+    ee-argv "0.1.x"
+    ee-class "1.x"
+    ee-log "^3.0.5"
+    ee-types "^2.1.4"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -2024,6 +2103,16 @@ log-symbols@3.0.0:
   integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
   dependencies:
     chalk "^2.4.2"
+
+logd-console-output@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/logd-console-output/-/logd-console-output-1.3.0.tgz#a49eb7a2ca25ce3b3e726b6e49d6639304241bae"
+  integrity sha512-Aau5xxpDXWBRIwl6zgConqmyNRBFq8VoQbzpQJjp9QVfrEtMgWUMbP2CUF9lCmMg0d2TQ79tEJA83+uQY36WAA==
+  dependencies:
+    app-root-path "^2.1.0"
+    chalk "^2.4.1"
+    ee-types "^2.2.0"
+    glob "^7.1.2"
 
 lolex@^4.2.0:
   version "4.2.0"
@@ -2793,6 +2882,17 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
+section-tests@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/section-tests/-/section-tests-1.3.1.tgz#60c09cc881da75d2921cc5c3487558882461e2cb"
+  integrity sha512-cZFz5XcvYzdHUCOwwrrSFPA9KZdukGENO7ukOgxpcScZaM8zRMIyR6LRySdgoX0nD7NH+XY85F1pQ7n89CZliw==
+  dependencies:
+    "@distributed-systems/callsite" "^1.1.0"
+    chalk "^1.1.3"
+    ee-log "^1.1.0"
+    ee-types "^2.1.4"
+    glob "^7.1.2"
+
 secure-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/secure-keys/-/secure-keys-1.0.0.tgz#f0c82d98a3b139a8776a8808050b824431087fca"
@@ -3112,6 +3212,11 @@ supports-color@7.1.0, supports-color@^7.1.0:
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
+
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
 supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
no-issue

This updates the stripe module to handle rate limiting for us, so that Ghost Core/importer doesn't need to worry about it.

It also exposes some required stripe method like `getCustomer` `createCustomer` and `createComplimentarySubscription` - all of these methods only deal with the stripe side of things and will allow the consumer to handle updating the database