### PR TITLE
🐛 Fixed default options for destroy method

### DIFF
--- a/packages/members-api/lib/users.js
+++ b/packages/members-api/lib/users.js
@@ -11,7 +11,7 @@ module.exports = function ({
         return Member.findOne(data, options);
     }
 
-    async function destroy(data, options) {
+    async function destroy(data, options = {}) {
         debug(`destroy id:${data.id} email:${data.email}`);
         const member = await Member.findOne(data, options);
         if (!member) {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/12150

- `destroy` method for a member expects an `options` param which should not be `undefined`
- Adds default value for `options` in case `destroy` method is called with just `data`