### PR TITLE
Updated magic-link to be more generic

### DIFF
--- a/packages/magic-link/README.md
+++ b/packages/magic-link/README.md
@@ -59,9 +59,9 @@ async function main() {
     /**
      *  POST /signin
      */
-    const {token, info} = await service.sendMagicLink({
+    const {url, info} = await service.sendMagicLink({
         email: 'test@example.com',
-        user: {
+        tokenData: {
             id: 'some-id'
         }
     });
@@ -74,7 +74,7 @@ async function main() {
     /**
      *  GET /signin
      */
-    const user = await service.getUserFromToken(token);
+    const data = await service.getDataFromToken(token);
     // createSomeKindOfSession(user);
 }
 

--- a/packages/magic-link/index.js
+++ b/packages/magic-link/index.js
@@ -83,16 +83,13 @@ function MagicLink(options) {
  *
  * @param {object} options
  * @param {string} options.email - The email to send magic link to
- * @param {string} options.payload - The payload for token
- * @param {object} options.subject - The subject to associate with the magic link (user id, or email)
+ * @param {object} options.tokenData - The data for token
  * @param {string=} [options.type='signin'] - The type to be passed to the url and content generator functions
  * @returns {Promise<{token: JSONWebToken, info: SentMessageInfo}>}
  */
 MagicLink.prototype.sendMagicLink = async function sendMagicLink(options) {
-    const payload = options.payload || {};
-    const token = jwt.sign(payload, this.secret, {
+    const token = jwt.sign(options.tokenData, this.secret, {
         algorithm: 'HS256',
-        subject: options.subject,
         expiresIn: '10m'
     });
 
@@ -109,18 +106,18 @@ MagicLink.prototype.sendMagicLink = async function sendMagicLink(options) {
 
     return {token, info};
 };
+
 /**
  * getMagicLink
  *
  * @param {object} options
- * @param {object} options.subject - The subject to associate with the magic link (user id, or email)
+ * @param {object} options.tokenData - The data for token
  * @param {string=} [options.type='signin'] - The type to be passed to the url and content generator functions
- * @returns {string} - signin URL
+ * @returns {URL} - signin URL
  */
 MagicLink.prototype.getMagicLink = function getMagicLink(options) {
-    const token = jwt.sign({}, this.secret, {
+    const token = jwt.sign(options.tokenData, this.secret, {
         algorithm: 'HS256',
-        subject: options.subject,
         expiresIn: '10m'
     });
 
@@ -130,31 +127,16 @@ MagicLink.prototype.getMagicLink = function getMagicLink(options) {
 };
 
 /**
- * getUserFromToken
+ * getDataFromToken
  *
  * @param {JSONWebToken} token - The token to decode
- * @returns {object} user - The user object associated with the magic link
+ * @returns {object} data - The data object associated with the magic link
  */
-MagicLink.prototype.getUserFromToken = function getUserFromToken(token) {
+MagicLink.prototype.getDataFromToken = function getDataFromToken(token) {
     /** @type {object} */
-    const claims = jwt.verify(token, this.secret, {
+    const tokenData = (jwt.verify(token, this.secret, {
         algorithms: ['HS256'],
         maxAge: '10m'
-    });
-    return claims.sub;
-};
-
-/**
- * getPayloadFromToken
- *
- * @param {JSONWebToken} token - The token to decode
- * @returns {object} payload - The payload object associated with the magic link
- */
-MagicLink.prototype.getPayloadFromToken = function getPayloadFromToken(token) {
-    /** @type {object} */
-    const claims = jwt.verify(token, this.secret, {
-        algorithms: ['HS256'],
-        maxAge: '10m'
-    });
-    return claims || {};
+    }));
+    return tokenData;
 };

--- a/packages/magic-link/index.js
+++ b/packages/magic-link/index.js
@@ -65,9 +65,9 @@ class MagicLink {
      * @param {object} options
      * @param {object} options.tokenData - The data for token
      * @param {string=} [options.type='signin'] - The type to be passed to the url and content generator functions
-     * @returns {URL} - signin URL
+     * @returns {Promise<URL>} - signin URL
      */
-    getMagicLink(options) {
+    async getMagicLink(options) {
         const token = jwt.sign(options.tokenData, this.secret, {
             algorithm: 'HS256',
             expiresIn: '10m'
@@ -82,9 +82,9 @@ class MagicLink {
      * getDataFromToken
      *
      * @param {JSONWebToken} token - The token to decode
-     * @returns {object} data - The data object associated with the magic link
+     * @returns {Promise<object>} data - The data object associated with the magic link
      */
-    getDataFromToken(token) {
+    async getDataFromToken(token) {
         /** @type {object} */
         const tokenData = (jwt.verify(token, this.secret, {
             algorithms: ['HS256'],

--- a/packages/magic-link/test/index.test.js
+++ b/packages/magic-link/test/index.test.js
@@ -27,7 +27,9 @@ describe('MagicLink', function () {
 
             const args = {
                 email: 'test@example.com',
-                subject: '420',
+                tokenData: {
+                    id: '420'
+                },
                 type: 'blazeit'
             };
             const {token} = await service.sendMagicLink(args);
@@ -52,7 +54,7 @@ describe('MagicLink', function () {
         });
     });
 
-    describe('#getUserFromToken', function () {
+    describe('#getDataFromToken', function () {
         it('Returns the user data which from the token that was encoded by #sendMagicLink', async function () {
             const options = {
                 secret,
@@ -67,13 +69,15 @@ describe('MagicLink', function () {
 
             const args = {
                 email: 'test@example.com',
-                subject: '420'
+                tokenData: {
+                    id: '420'
+                }
             };
 
             const {token} = await service.sendMagicLink(args);
-            const subject = service.getUserFromToken(token);
+            const data = service.getDataFromToken(token);
 
-            should.deepEqual(subject, args.subject);
+            should.deepEqual(data.id, args.tokenData.id);
         });
     });
 });

--- a/packages/magic-link/test/index.test.js
+++ b/packages/magic-link/test/index.test.js
@@ -75,7 +75,7 @@ describe('MagicLink', function () {
             };
 
             const {token} = await service.sendMagicLink(args);
-            const data = service.getDataFromToken(token);
+            const data = await service.getDataFromToken(token);
 
             should.deepEqual(data.id, args.tokenData.id);
         });

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -169,7 +169,9 @@ module.exports = function MembersApi({
             }));
         }
 
-        const member = await getMemberIdentityData(email);
+        const member = await users.get(email, {
+            withRelated: ['labels']
+        });
 
         if (!member) {
             return Promise.reject(new common.errors.NotFoundError({

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -105,17 +105,17 @@ module.exports = function MembersApi({
         Member
     });
 
-    async function sendEmailWithMagicLink({email, requestedType, payload, options = {forceEmailType: false}}) {
-        if (options.forceEmailType) {
-            return magicLinkService.sendMagicLink({email, payload, subject: email, type: requestedType});
+    async function sendEmailWithMagicLink({email, requestedType, tokenData, options = {forceEmailType: false}}) {
+        let type = requestedType;
+        if (!options.forceEmailType) {
+            const member = await users.get({email});
+            if (member) {
+                type = 'signin';
+            } else if (type !== 'subscribe') {
+                type = 'signup';
+            }
         }
-        const member = await users.get({email});
-        if (member) {
-            return magicLinkService.sendMagicLink({email, payload, subject: email, type: 'signin'});
-        } else {
-            const type = requestedType === 'subscribe' ? 'subscribe' : 'signup';
-            return magicLinkService.sendMagicLink({email, payload, subject: email, type});
-        }
+        return magicLinkService.sendMagicLink({email, type, tokenData: Object.assign({email}, tokenData)});
     }
 
     function getMagicLink(email) {
@@ -123,8 +123,7 @@ module.exports = function MembersApi({
     }
 
     async function getMemberDataFromMagicLinkToken(token) {
-        const email = await magicLinkService.getUserFromToken(token);
-        const {labels = [], name = '', oldEmail} = await magicLinkService.getPayloadFromToken(token);
+        const {email, labels = [], name = '', oldEmail} = await magicLinkService.getDataFromToken(token);
         if (!email) {
             return null;
         }
@@ -198,7 +197,6 @@ module.exports = function MembersApi({
 
     middleware.sendMagicLink.use(body.json(), async function (req, res) {
         const {email, emailType, oldEmail} = req.body;
-        const payload = {};
 
         if (!email) {
             res.writeHead(400);
@@ -214,18 +212,16 @@ module.exports = function MembersApi({
                     });
                 }
             }
-            let extraPayload = {};
+
             if (!allowSelfSignup) {
                 const member = await users.get({email});
                 if (member) {
-                    extraPayload = _.pick(req.body, ['oldEmail']);
-                    Object.assign(payload, extraPayload);
-                    await sendEmailWithMagicLink({email, requestedType: emailType, payload});
+                    const tokenData = _.pick(req.body, ['oldEmail']);
+                    await sendEmailWithMagicLink({email, tokenData, requestedType: emailType});
                 }
             } else {
-                extraPayload = _.pick(req.body, ['labels', 'name', 'oldEmail']);
-                Object.assign(payload, extraPayload);
-                await sendEmailWithMagicLink({email, requestedType: emailType, payload});
+                const tokenData = _.pick(req.body, ['labels', 'name', 'oldEmail']);
+                await sendEmailWithMagicLink({email, tokenData, requestedType: emailType});
             }
             res.writeHead(201);
             return res.end('Created.');


### PR DESCRIPTION
no-issue

This removes the concept of `subject` & `payload` from the function
signatures, making the implementation a little more generic, and less
JWT centric.

We also replace `getUserFromToken` and `getPayloadFromToken` with a single
method `getDataFromToken`, which will contain all the necessary data.

We also update `members-api` to work with the updates.