### PR TITLE
Updated MagicLink to accept a "TokenProvider"

### DIFF
--- a/packages/magic-link/JWTTokenProvider.js
+++ b/packages/magic-link/JWTTokenProvider.js
@@ -1,0 +1,50 @@
+const jwt = require('jsonwebtoken');
+
+/**
+ * @typedef {import('jsonwebtoken').Secret} Secret
+ * @typedef {string} JSONWebToken
+ */
+
+/**
+ * @typedef {Object<string, any>} Data
+ */
+
+module.exports = class JWTTokenProvider {
+    /**
+     * @param {Secret} secret
+     */
+    constructor(secret) {
+        this.secret = secret;
+    }
+
+    /**
+     * @param {Data} data
+     * @returns {Promise<JSONWebToken>}
+     */
+    async create(data) {
+        const token = jwt.sign(data, this.secret, {
+            algorithm: 'HS256',
+            expiresIn: '10m'
+        });
+
+        return token;
+    }
+
+    /**
+     * @param {JSONWebToken} token
+     * @returns {Promise<Data>}
+     */
+    async validate(token) {
+        /** @type any */
+        const claims = jwt.verify(token, this.secret, {
+            algorithms: ['HS256'],
+            maxAge: '10m'
+        });
+
+        if (!claims || typeof claims === 'string') {
+            throw new Error();
+        }
+
+        return claims;
+    }
+};

--- a/packages/magic-link/README.md
+++ b/packages/magic-link/README.md
@@ -12,24 +12,13 @@ or
 ## Usage
 
 ```js
-const util = require('util');
 const crypto = require('crypto');
 const nodemailer = require('nodemailer');
 const MagicLink = require('@tryghost/magic-link');
+const JWTTokenProvider = require('@tryghost/magic-link/JWTTokenProvider');
 
 async function main() {
-    const generateKeyPair = util.promisify(crypto.generateKeyPair);
-    const {publicKey, privateKey} = await generateKeyPair('rsa', {
-        modulusLength: 4096,
-        publicKeyEncoding: {
-            type: 'pkcs1',
-            format: 'pem'
-        },
-        privateKeyEncoding: {
-            type: 'pkcs1',
-            format: 'pem'
-        }
-    });
+    const jwtSecret = crypto.randomBytes(16).toString('hex');
 
     // https://nodemailer.com/about/#example
     const testAccount = await nodemailer.createTestAccount();
@@ -48,9 +37,8 @@ async function main() {
     });
 
     const service = MagicLink({
+        tokenProvider: new JWTTokenProvider(jwtSecret),
         transporter,
-        publicKey,
-        privateKey,
         getSigninURL(token) {
             return `http://example.com/signin?token=${token}`
         }

--- a/packages/magic-link/test/index.test.js
+++ b/packages/magic-link/test/index.test.js
@@ -1,6 +1,7 @@
 const should = require('should');
 const sinon = require('sinon');
 const MagicLink = require('../');
+const JWTTokenProvider = require('../JWTTokenProvider');
 const crypto = require('crypto');
 
 const sandbox = sinon.createSandbox();
@@ -14,7 +15,7 @@ describe('MagicLink', function () {
     describe('#sendMagicLink', function () {
         it('Sends an email to the user with a link generated from getSigninURL(token, type)', async function () {
             const options = {
-                secret,
+                tokenProvider: new JWTTokenProvider(secret),
                 getSigninURL: sandbox.stub().returns('FAKEURL'),
                 getText: sandbox.stub().returns('SOMETEXT'),
                 getHTML: sandbox.stub().returns('SOMEHTML'),
@@ -57,7 +58,7 @@ describe('MagicLink', function () {
     describe('#getDataFromToken', function () {
         it('Returns the user data which from the token that was encoded by #sendMagicLink', async function () {
             const options = {
-                secret,
+                tokenProvider: new JWTTokenProvider(secret),
                 getSigninURL: sandbox.stub().returns('FAKEURL'),
                 getText: sandbox.stub().returns('SOMETEXT'),
                 getHTML: sandbox.stub().returns('SOMEHTML'),

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const {Router} = require('express');
 const body = require('body-parser');
+const JWTTokenProvider = require('@tryghost/magic-link/JWTTokenProvider');
 const MagicLink = require('@tryghost/magic-link');
 const StripePaymentProcessor = require('./lib/stripe');
 const Tokens = require('./lib/tokens');
@@ -93,7 +94,7 @@ module.exports = function MembersApi({
 
     const magicLinkService = new MagicLink({
         transporter,
-        secret,
+        tokenProvider: new JWTTokenProvider(secret),
         getSigninURL,
         getText,
         getHTML,


### PR DESCRIPTION
This adds a layer of abstraction between the magic-link module and the
token generation, allowing us to switch out the token generation in the
future, when implementing single use tokens stored in a database