### PR TITLE
Updated members-api to accept a TokenProvider

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -18,7 +18,7 @@ module.exports = function MembersApi({
     auth: {
         allowSelfSignup = true,
         getSigninURL,
-        secret
+        tokenProvider
     },
     paymentConfig,
     mail: {
@@ -93,7 +93,7 @@ module.exports = function MembersApi({
 
     const magicLinkService = new MagicLink({
         transporter,
-        tokenProvider: new MagicLink.JWTTokenProvider(secret),
+        tokenProvider,
         getSigninURL,
         getText,
         getHTML,


### PR DESCRIPTION
no-issue

This paves the way for Ghost to be able to pass in a custom token
provider which will handle the shortening of tokens and making them
single use.