### PR TITLE
Updated customer email in Stripe when member email changes

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -164,9 +164,9 @@ module.exports = function MembersApi({
 
     async function setMemberGeolocationFromIp(email, ip) {
         if (!email || !ip) {
-            return Promise.reject(new common.errors.IncorrectUsageError({
+            throw new common.errors.IncorrectUsageError({
                 message: 'setMemberGeolocationFromIp() expects email and ip arguments to be present'
-            }));
+            });
         }
 
         const member = await users.get(email, {
@@ -174,9 +174,9 @@ module.exports = function MembersApi({
         });
 
         if (!member) {
-            return Promise.reject(new common.errors.NotFoundError({
+            throw new common.errors.NotFoundError({
                 message: `Member with email address ${email} does not exist`
-            }));
+            });
         }
 
         // max request time is 500ms so shouldn't slow requests down too much

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -182,8 +182,8 @@ module.exports = function MembersApi({
         // max request time is 500ms so shouldn't slow requests down too much
         let geolocation = JSON.stringify(await getGeolocationFromIP(ip));
         if (geolocation) {
-            const data = Object.assign(member.toJSON(), {geolocation});
-            await users.update(data, {id: member.id});
+            member.geolocation = geolocation;
+            await users.update(member, {id: member.id});
         }
 
         return getMemberIdentityData(email);

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -169,7 +169,7 @@ module.exports = function MembersApi({
             });
         }
 
-        const member = await users.get(email, {
+        const member = await users.get({email}, {
             withRelated: ['labels']
         });
 
@@ -182,8 +182,8 @@ module.exports = function MembersApi({
         // max request time is 500ms so shouldn't slow requests down too much
         let geolocation = JSON.stringify(await getGeolocationFromIP(ip));
         if (geolocation) {
-            member.geolocation = geolocation;
-            await users.update(member, {id: member.id});
+            const data = Object.assign(member.toJSON(), {geolocation});
+            await users.update(data, {id: member.id});
         }
 
         return getMemberIdentityData(email);

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -418,6 +418,25 @@ module.exports = class StripePaymentProcessor {
         await this._updateSubscription(subscription);
     }
 
+    /**
+     * @param {string} customerId - The ID of the Stripe Customer to update
+     * @param {string} email - The email to update
+     *
+     * @returns {Promise<null>}
+     */
+    async updateStripeCustomerEmail(customerId, email) {
+        try {
+            await update(this._stripe, 'customers', customerId, {
+                email
+            });
+        } catch (err) {
+            this.logging.error(err, {
+                message: 'Failed to update Stripe Customer email'
+            });
+        }
+        return null;
+    }
+
     async _updateCustomer(member, customer) {
         debug(`Attaching customer to member ${member.get('email')} ${customer.id}`);
         await this.storage.set({


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12055

This adds handling to the `update` method for members, which will check if the `email` property has changed on the member, and if so, iterate through all associated Stripe Customers, updating their email.