### PR TITLE
Removed old webhook cleanup code

### DIFF
--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -1,6 +1,6 @@
 const debug = require('ghost-ignition').debug('stripe');
 const _ = require('lodash');
-const {retrieve, list, create, update, del} = require('./api/stripeRequests');
+const {retrieve, create, update, del} = require('./api/stripeRequests');
 const api = require('./api');
 
 const STRIPE_API_VERSION = '2019-09-09';
@@ -74,24 +74,6 @@ module.exports = class StripePaymentProcessor {
                 'invoice.payment_failed'
             ]
         };
-
-        // @TODO Delete this next time you're here
-        // This is a fix for the previous release of Ghost (3.25.0)
-        try {
-            const webhooks = await list(this._stripe, 'webhookEndpoints', {
-                limit: 100
-            });
-
-            const webhooksToCleanup = webhooks.data.filter((webhook) => {
-                return webhook.url === config.webhookHandlerUrl.slice(0, -1) || webhook.url === config.webhookHandlerUrl;
-            });
-
-            for (const webhookToCleanup of webhooksToCleanup) {
-                await del(this._stripe, 'webhookEndpoints', webhookToCleanup.id);
-            }
-        } catch (err) {
-            this.logging.warn(`There was an error cleaning up the old webhooks`);
-        }
 
         const setupWebhook = async (id, secret, opts = {}) => {
             if (!id || !secret || opts.forceCreate) {


### PR DESCRIPTION
no-issue

This is no longer necessary anymore, it would delete all webhooks which
matched the current webhook handler URL, which is undesirable