### PR TITLE
Added Stripe webhook listener for subscription created event

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -345,6 +345,10 @@ module.exports = function MembersApi({
                 await stripe.handleCustomerSubscriptionUpdatedWebhook(event.data.object);
             }
 
+            if (event.type === 'customer.subscription.created') {
+                await stripe.handleCustomerSubscriptionCreatedWebhook(event.data.object);
+            }
+
             if (event.type === 'invoice.payment_succeeded') {
                 await stripe.handleInvoicePaymentSucceededWebhook(event.data.object);
             }

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -70,6 +70,7 @@ module.exports = class StripePaymentProcessor {
                 'checkout.session.completed',
                 'customer.subscription.deleted',
                 'customer.subscription.updated',
+                'customer.subscription.created',
                 'invoice.payment_succeeded',
                 'invoice.payment_failed'
             ]
@@ -383,6 +384,10 @@ module.exports = class StripePaymentProcessor {
     }
 
     async handleCustomerSubscriptionUpdatedWebhook(subscription) {
+        await this._updateSubscription(subscription);
+    }
+
+    async handleCustomerSubscriptionCreatedWebhook(subscription) {
         await this._updateSubscription(subscription);
     }
 


### PR DESCRIPTION
no-issue

Subscription created events are required for migrating Stripe subscriptions from
alternative platforms, which involves creating a new subscription for a customer
(outside of Ghost) before cancelling the original subscription.