### PR TITLE
Added `unpaid` and `past_due` subscription status as paid member

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -64,6 +64,22 @@ module.exports = function MembersApi({
             return true;
         }
 
+        const firstUnpaidSubscription = await StripeCustomerSubscription.findOne({
+            status: 'unpaid'
+        });
+
+        if (firstUnpaidSubscription) {
+            return true;
+        }
+
+        const firstPastDueSubscription = await StripeCustomerSubscription.findOne({
+            status: 'past_due'
+        });
+
+        if (firstPastDueSubscription) {
+            return true;
+        }
+
         return false;
     }
 

--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -341,7 +341,7 @@ module.exports = class StripePaymentProcessor {
         const subscriptions = await this.getSubscriptions(member);
 
         return subscriptions.filter((subscription) => {
-            return subscription.status === 'active' || subscription.status === 'trialing';
+            return ['active', 'trialing', 'unpaid', 'past_due'].includes(subscription.status);
         });
     }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12256 , https://github.com/TryGhost/Ghost/issues/12255

Currently when listing subscriptions for Members, we were only showing the subscriptions which have a status of trialing or active.

Based on discussion, the `unpaid` and `past_due` states on Stripe also represent owner's intention of considering a subscription as active instead of `cancelled`, so we allow any subscriptions under these 2 states to be also listed for a member and consider them as `paid`.

- Subscriptions will go into a past_due state if the payment is missed, this should be considered a grace period where the member still has access.

- After this the subscriptions will either go to the unpaid or the cancelled state - this can be configured on an account by account basis in the Stripe dashboard. `unpaid` is considered as an intention to keep the subscription to allow for re-activation later.