### PR TITLE
Added custom action for Portal and email fix

### DIFF
--- a/packages/magic-link/index.js
+++ b/packages/magic-link/index.js
@@ -22,7 +22,7 @@ class MagicLink {
      * @param {object} options
      * @param {MailTransporter} options.transporter
      * @param {TokenProvider<Token, TokenData>} options.tokenProvider
-     * @param {(token: Token, type: string) => URL} options.getSigninURL
+     * @param {(token: Token, type: string, requestSrc?: string) => URL} options.getSigninURL
      * @param {typeof defaultGetText} [options.getText]
      * @param {typeof defaultGetHTML} [options.getHTML]
      * @param {typeof defaultGetSubject} [options.getSubject]
@@ -44,6 +44,7 @@ class MagicLink {
      *
      * @param {object} options
      * @param {string} options.email - The email to send magic link to
+     * @param {string} options.requestSrc - The source magic link was requested from
      * @param {TokenData} options.tokenData - The data for token
      * @param {string=} [options.type='signin'] - The type to be passed to the url and content generator functions
      * @returns {Promise<{token: Token, info: SentMessageInfo}>}
@@ -52,8 +53,9 @@ class MagicLink {
         const token = await this.tokenProvider.create(options.tokenData);
 
         const type = options.type || 'signin';
+        const requestSrc = options.requestSrc;
 
-        const url = this.getSigninURL(token, type);
+        const url = this.getSigninURL(token, type, requestSrc);
 
         const info = await this.transporter.sendMail({
             to: options.email,

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -121,7 +121,7 @@ module.exports = function MembersApi({
         Member
     });
 
-    async function sendEmailWithMagicLink({email, requestedType, tokenData, options = {forceEmailType: false}}) {
+    async function sendEmailWithMagicLink({email, requestedType, requestSrc, tokenData, options = {forceEmailType: false}}) {
         let type = requestedType;
         if (!options.forceEmailType) {
             const member = await users.get({email});
@@ -131,7 +131,7 @@ module.exports = function MembersApi({
                 type = 'signup';
             }
         }
-        return magicLinkService.sendMagicLink({email, type, tokenData: Object.assign({email}, tokenData)});
+        return magicLinkService.sendMagicLink({email, type, requestSrc, tokenData: Object.assign({email}, tokenData)});
     }
 
     function getMagicLink(email) {
@@ -214,7 +214,7 @@ module.exports = function MembersApi({
     };
 
     middleware.sendMagicLink.use(body.json(), async function (req, res) {
-        const {email, emailType, oldEmail} = req.body;
+        const {email, emailType, oldEmail, requestSrc} = req.body;
 
         if (!email) {
             res.writeHead(400);
@@ -236,11 +236,11 @@ module.exports = function MembersApi({
                 if (member) {
                     const tokenData = _.pick(req.body, ['oldEmail']);
                     const forceEmailType = oldEmail ? true : false;
-                    await sendEmailWithMagicLink({email, tokenData, requestedType: emailType, options: {forceEmailType}});
+                    await sendEmailWithMagicLink({email, tokenData, requestedType: emailType, requestSrc, options: {forceEmailType}});
                 }
             } else {
                 const tokenData = _.pick(req.body, ['labels', 'name', 'oldEmail']);
-                await sendEmailWithMagicLink({email, tokenData, requestedType: emailType});
+                await sendEmailWithMagicLink({email, tokenData, requestedType: emailType, requestSrc});
             }
             res.writeHead(201);
             return res.end('Created.');


### PR DESCRIPTION
- Removed magic link email for upgrade checkout 

Previously, we were sending a magic link email to signup in case a logged-in member upgrades to a paid account, as we didn't check for logged in status while sending the magic link and always sent one on finishing checkout. Since Portal allows members to upgrade their account from free, it doesn't make sense to send another email to signup after completing checkout.

The fix here adds a metadata `checkoutType` to checkout session creation which can be passed in with `upgrade` value to denote an existing member is upgrading and doesn't need an email.

- Added request source option for magic link url 

Currently, Ghost uses standard query params like action, success and stripe for all actions and redirects to a site for member events. This needed to be extended to allow for portal specific query params so it doesn't overlap with specific theme handling or custom notifications.

The change here adds an extra option - `requestSrc` - which can be passed when using magic link API to send a link which is passed down to `getSigninURL`, and allows the `action` param to configured to `portal-action` when magic links are sent from Portal