### PR TITLE
Stored cancellation reason in local database

### DIFF
--- a/packages/members-api/lib/stripe/index.js
+++ b/packages/members-api/lib/stripe/index.js
@@ -453,6 +453,7 @@ module.exports = class StripePaymentProcessor {
             subscription_id: subscription.id,
             status: subscription.status,
             cancel_at_period_end: subscription.cancel_at_period_end,
+            cancellation_reason: subscription.metadata && subscription.metadata.cancellation_reason || null,
             current_period_end: new Date(subscription.current_period_end * 1000),
             start_date: new Date(subscription.start_date * 1000),
             default_payment_card_last4: payment && payment.card && payment.card.last4 || null,


### PR DESCRIPTION
no-issue

This ensures that we keep our local database in sync with the metadata in Stripe