### PR TITLE
Ensured latest subscription data is always stored

### DIFF
--- a/packages/members-api/lib/repositories/member/index.js
+++ b/packages/members-api/lib/repositories/member/index.js
@@ -169,7 +169,7 @@ module.exports = class MemberRepository {
             throw new Error('Subscription is not associated with a customer for the member');
         }
 
-        const subscription = data.subscription;
+        const subscription = await this._stripeAPIService.getSubscription(data.subscription.id);
         let paymentMethodId;
         if (!subscription.default_payment_method) {
             paymentMethodId = null;


### PR DESCRIPTION
no-issue

If we receive webhooks out of order, e.g. a
`customer.subscription.updated` with a status of 'active', followed by a
`customer.subscription.created` with a status of 'incomplete'. We would
overwrite the correct value with data from the "older" webhook. This
ensures that we always fetch the latest data from the Stripe API before
storing in the database.