### PR TITLE
🐛 Fixed members API unhandled exception when unknown plan name is…

### DIFF
--- a/packages/members-api/lib/controllers/router/index.js
+++ b/packages/members-api/lib/controllers/router/index.js
@@ -223,6 +223,11 @@ module.exports = class RouterController {
 
         const plan = this._stripePlansService.getPlan(planName);
 
+        if (!plan) {
+            res.writeHead(400);
+            return res.end('Bad Request.');
+        }
+
         let email;
         try {
             if (!identity) {


### PR DESCRIPTION
closes TryGhost/Ghost#12792

When you pass an unknown plan name to ghost members API (e. g. `/members/api/create-stripe-checkout-session/`), API hangs and Ghost throws unhandled Cannot read property 'id' of undefined error.

```js
UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'id' of undefined
    at StripeAPIService.createCheckoutSession (/var/home/Ghost/Ghost/node_modules/@tryghost/members-api/lib/services/stripe-api/index.js:357:32)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async RouterController.createCheckoutSession (/var/home/Ghost/Ghost/node_modules/@tryghost/members-api/lib/controllers/router/index.js:243:29)
```

The issue is in [Members/packages/members-api/lib/controllers/router/index.js](https://github.com/TryGhost/Members/blob/main/packages/members-api/lib/controllers/router/index.js#L224). It uses `_stripePlansService.getPlan(planName)`, which can return undefined when no plan exists with that name, but the router doesn't handle this case.

Added check if the returned plan is defined with `Bad Request` response.