### PR TITLE
🐛 Fixed incorrect mrr delta calculation

### DIFF
--- a/packages/members-api/lib/repositories/member/index.js
+++ b/packages/members-api/lib/repositories/member/index.js
@@ -300,14 +300,16 @@ module.exports = class MemberRepository {
             if (status === 'incomplete_expired') {
                 return 0;
             }
-            const modifier = status === 'canceled' ? -1 : 1;
+            if (status === 'canceled') {
+                return 0;
+            }
 
             if (interval === 'year') {
-                return modifier * Math.floor(amount / 12);
+                return Math.floor(amount / 12);
             }
 
             if (interval === 'month') {
-                return modifier * amount;
+                return amount;
             }
         }
         if (model) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/595

For a canceled subscription, the desired MRR delta is to reduce by negative of original amount, but our logic was incorrectly reducing it by double which led to big gap between real MRR and one shown on Dashboard.

- Fixes calculation for MRR change for canceled subscriptions