### PR TITLE
Updated Stripe major version and types

### DIFF
--- a/packages/members-api/lib/services/stripe-plans/index.js
+++ b/packages/members-api/lib/services/stripe-plans/index.js
@@ -12,14 +12,14 @@ module.exports = class StripeService {
     }) {
         this._stripeAPIService = stripeAPIService;
         this._configured = false;
-        /** @type {import('stripe').products.IProduct} */
+        /** @type {import('stripe').Stripe.Product} */
         this._product = null;
-        /** @type {import('stripe').plans.IPlan[]} */
+        /** @type {import('stripe').Stripe.Plan[]} */
         this._plans = null;
     }
 
     /**
-     * @returns {import('stripe').products.IProduct}
+     * @returns {import('stripe').Stripe.Product}
      */
     getProduct() {
         if (!this._configured) {
@@ -29,7 +29,7 @@ module.exports = class StripeService {
     }
 
     /**
-     * @returns {import('stripe').plans.IPlan[]}
+     * @returns {import('stripe').Stripe.Plan[]}
      */
     getPlans() {
         if (!this._configured) {
@@ -40,7 +40,7 @@ module.exports = class StripeService {
 
     /**
      * @param {string} nickname
-     * @returns {import('stripe').plans.IPlan}
+     * @returns {import('stripe').Stripe.Plan}
      */
     getPlan(nickname) {
         if (!this._configured) {
@@ -53,7 +53,7 @@ module.exports = class StripeService {
 
     /**
      * @param {Currency} currency
-     * @returns {import('stripe').plans.IPlan}
+     * @returns {import('stripe').Stripe.Plan}
      */
     getComplimentaryPlan(currency) {
         if (!this._configured) {

--- a/packages/members-api/lib/services/stripe-webhook/index.js
+++ b/packages/members-api/lib/services/stripe-webhook/index.js
@@ -50,7 +50,7 @@ module.exports = class StripeWebhookService {
             throw error;
         }
 
-        /** @type {import('stripe').events.EventType[]} */
+        /** @type {import('stripe').Stripe.WebhookEndpointCreateParams.EnabledEvent[]} */
         const events = [
             'checkout.session.completed',
             'customer.subscription.deleted',
@@ -109,14 +109,14 @@ module.exports = class StripeWebhookService {
     /**
      * @param {string} body
      * @param {string} signature
-     * @returns {import('stripe').events.IEvent}
+     * @returns {import('stripe').Stripe.Event}
      */
     parseWebhook(body, signature) {
         return this._stripeAPIService.parseWebhook(body, signature, this._webhookSecret);
     }
 
     /**
-     * @param {import('stripe').events.IEvent} event
+     * @param {import('stripe').Stripe.Event} event
      *
      * @returns {Promise<void>}
      */
@@ -142,7 +142,7 @@ module.exports = class StripeWebhookService {
     }
 
     /**
-     * @param {import('stripe').invoices.IInvoice} invoice
+     * @param {import('stripe').Stripe.Invoice} invoice
      *
      * @returns {Promise<void>}
      */

--- a/packages/members-api/package.json
+++ b/packages/members-api/package.json
@@ -17,7 +17,6 @@
     "gateway"
   ],
   "devDependencies": {
-    "@types/stripe": "7.13.24",
     "jsdom": "15.2.1",
     "mocha": "6.2.3",
     "nock": "12.0.3",
@@ -37,7 +36,7 @@
     "leaky-bucket": "2.2.0",
     "lodash": "^4.17.11",
     "node-jose": "^1.1.3",
-    "stripe": "^7.4.0"
+    "stripe": "^8.142.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,6 +202,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.51.tgz#446a67af8c5ff98947d7cef296484c6ad47ddb16"
   integrity sha512-6ILqt8iNThALrxDv2Q4LyYFQxULQz96HKNIFd4s9QRQaiHINYeUpLqeU/2IU7YMtvipG1fQVAy//vY8/fX1Y9w==
 
+"@types/node@>=8.1.0":
+  version "14.14.37"
+  resolved "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
+  integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
+
 "@types/nodemailer@6.4.0":
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.0.tgz#d8c039be3ed685c4719a026455555be82c124b74"
@@ -226,13 +231,6 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
-
-"@types/stripe@7.13.24":
-  version "7.13.24"
-  resolved "https://registry.yarnpkg.com/@types/stripe/-/stripe-7.13.24.tgz#a82416d949bad90bc283db399958fa0c3cbe41a3"
-  integrity sha512-jlY9nvZMHSikta0udPubW5HcIl3C9waWPHqAi2oCL9dn91rwJLfKp/A9b7Trif+YTOv0StACk1gGLyBSgXQNmA==
-  dependencies:
-    "@types/node" "*"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -3282,11 +3280,12 @@ strip-json-comments@3.1.1, strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-stripe@^7.4.0:
-  version "7.15.0"
-  resolved "https://registry.yarnpkg.com/stripe/-/stripe-7.15.0.tgz#03593caec169b698997c091b07d21da701eeee18"
-  integrity sha512-TmouNGv1rIU7cgw7iFKjdQueJSwYKdPRPBuO7eNjrRliZUnsf2bpJqYe+n6ByarUJr38KmhLheVUxDyRawByPQ==
+stripe@^8.142.0:
+  version "8.142.0"
+  resolved "https://registry.npmjs.org/stripe/-/stripe-8.142.0.tgz#8a55e92837ea5c8bc4f65754df01c004a2beebed"
+  integrity sha512-0CimG7f5lsqD+qf+Vv8QgBPuYT0hqn/gfXBNEdeQxIIA+WUrxqXEyS5C0r5YIxa/Et5WiByfCpXJdMsxh4G35Q==
   dependencies:
+    "@types/node" ">=8.1.0"
     qs "^6.6.0"
 
 supports-color@6.0.0:


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/593

- Bumps `stripe` library major version to v8 - 8.142
- Bumps default Stripe version to latest - '2020-08-27'
- Updated webhook Stripe version to latest - '2020-08-27'
- Removes `@types/stripe` in favor of first-class types support in `stripe` directly
- Updates types across files