### PR TITLE
Populate stripe prices and products for existing customers

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -156,7 +156,7 @@ module.exports = function MembersApi({
             plans: stripeConfig.plans,
             mode: process.env.NODE_ENV || 'development'
         }),
-        stripeMigrations.populateProductsAndPrices();
+        stripeMigrations.populateProductsAndPrices(),
         stripeWebhookService.configure({
             webhookSecret: process.env.WEBHOOK_SECRET,
             webhookHandlerUrl: stripeConfig.webhookHandlerUrl,

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -12,6 +12,7 @@ const MemberRepository = require('./lib/repositories/member');
 const EventRepository = require('./lib/repositories/event');
 const RouterController = require('./lib/controllers/router');
 const MemberController = require('./lib/controllers/member');
+const StripeMigrations = require('./lib/migrations');
 
 module.exports = function MembersApi({
     tokenConfig: {
@@ -41,7 +42,10 @@ module.exports = function MembersApi({
         MemberPaidSubscriptionEvent,
         MemberPaymentEvent,
         MemberStatusEvent,
-        MemberEmailChangeEvent
+        MemberEmailChangeEvent,
+        StripeProduct,
+        StripePrice,
+        Product
     },
     logger
 }) {
@@ -58,6 +62,15 @@ module.exports = function MembersApi({
             appInfo: stripeConfig.appInfo,
             enablePromoCodes: stripeConfig.enablePromoCodes
         },
+        logger
+    });
+
+    const stripeMigrations = new StripeMigrations({
+        stripeAPIService,
+        StripeCustomerSubscription,
+        StripeProduct,
+        StripePrice,
+        Product,
         logger
     });
 
@@ -143,6 +156,7 @@ module.exports = function MembersApi({
             plans: stripeConfig.plans,
             mode: process.env.NODE_ENV || 'development'
         }),
+        stripeMigrations.populateProductsAndPrices();
         stripeWebhookService.configure({
             webhookSecret: process.env.WEBHOOK_SECRET,
             webhookHandlerUrl: stripeConfig.webhookHandlerUrl,

--- a/packages/members-api/lib/migrations/index.js
+++ b/packages/members-api/lib/migrations/index.js
@@ -1,24 +1,11 @@
 const _ = require('lodash');
 
 /**
- * @typedef {import('stripe').Stripe.Customer} ICustomer
- * @typedef {import('stripe').Stripe.Product} IProduct
- * @typedef {import('stripe').Stripe.Plan} IPlan
- * @typedef {import('stripe').Stripe.Price} IPrice
- * @typedef {import('stripe').Stripe.WebhookEndpoint} IWebhookEndpoint
- */
-
-/**
  * @typedef {object} ILogger
  * @prop {(x: any) => void} error
  * @prop {(x: any) => void} info
  * @prop {(x: any) => void} warn
  */
-
-/**
- * @typedef {'customers'|'subscriptions'|'plans'} StripeResource
- */
-
 module.exports = class StripeMigrations {
     /**
      * StripeMigrations
@@ -32,8 +19,15 @@ module.exports = class StripeMigrations {
      * @param {any} params.Product
      * @param {any} params.stripeAPIService
      */
-    constructor({logger, StripeCustomerSubscription, StripeProduct, StripePrice, Product, stripeAPIService}) {
-        this.logging = logger;
+    constructor({
+        StripeCustomerSubscription,
+        StripeProduct,
+        StripePrice,
+        Product,
+        stripeAPIService,
+        logger
+    }) {
+        this._logging = logger;
         this._StripeCustomerSubscription = StripeCustomerSubscription;
         this._StripeProduct = StripeProduct;
         this._StripePrice = StripePrice;
@@ -62,7 +56,7 @@ module.exports = class StripeMigrations {
             const uniquePlans = _.uniq(subscriptions.map(d => _.get(d, 'plan.id')));
 
             let stripePlans = [];
-
+            this._logging.info(`Adding ${uniquePlans.length} plans from Stripe`);
             for (const plan of uniquePlans) {
                 const stripePlan = await this._StripeAPIService.getPlan(plan, {
                     expand: ['product']

--- a/packages/members-api/lib/migrations/index.js
+++ b/packages/members-api/lib/migrations/index.js
@@ -1,0 +1,92 @@
+const _ = require('lodash');
+
+/**
+ * @typedef {import('stripe').Stripe.Customer} ICustomer
+ * @typedef {import('stripe').Stripe.Product} IProduct
+ * @typedef {import('stripe').Stripe.Plan} IPlan
+ * @typedef {import('stripe').Stripe.Price} IPrice
+ * @typedef {import('stripe').Stripe.WebhookEndpoint} IWebhookEndpoint
+ */
+
+/**
+ * @typedef {object} ILogger
+ * @prop {(x: any) => void} error
+ * @prop {(x: any) => void} info
+ * @prop {(x: any) => void} warn
+ */
+
+/**
+ * @typedef {'customers'|'subscriptions'|'plans'} StripeResource
+ */
+
+module.exports = class StripeMigrations {
+    /**
+     * StripeMigrations
+     *
+     * @param {object} params
+     *
+     * @param {ILogger} params.logger
+     * @param {any} params.StripeCustomerSubscription
+     * @param {any} params.StripeProduct
+     * @param {any} params.StripePrice
+     * @param {any} params.Product
+     * @param {any} params.stripeAPIService
+     */
+    constructor({logger, StripeCustomerSubscription, StripeProduct, StripePrice, Product, stripeAPIService}) {
+        this.logging = logger;
+        this._StripeCustomerSubscription = StripeCustomerSubscription;
+        this._StripeProduct = StripeProduct;
+        this._StripePrice = StripePrice;
+        this._Product = Product;
+        this._StripeAPIService = stripeAPIService;
+    }
+
+    async populateProductsAndPrices() {
+        const subscriptionModels = await this._StripeCustomerSubscription.findAll();
+        const priceModels = await this._StripePrice.findAll();
+        const productModels = await this._StripeProduct.findAll();
+        const subscriptions = subscriptionModels.toJSON();
+        const prices = priceModels.toJSON();
+        const products = productModels.toJSON();
+        const {data} = await this._Product.findPage({
+            limit: 1
+        });
+        const defaultProduct = data[0] && data[0].toJSON();
+
+        /** Only run when -
+         * No rows in stripe_products,
+         * No rows in stripe_prices,
+         * One or more rows in members_stripe_customers_subscriptions
+         * */
+        if (subscriptions.length > 0 && products.length === 0 && prices.length === 0) {
+            const uniquePlans = _.uniq(subscriptions.map(d => _.get(d, 'plan.id')));
+
+            let stripePlans = [];
+
+            for (const plan of uniquePlans) {
+                const stripePlan = await this._StripeAPIService.getPlan(plan, {
+                    expand: ['product']
+                });
+                const stripeProduct = stripePlan.product;
+
+                await this._StripeProduct.upsert({
+                    product_id: defaultProduct.id,
+                    stripe_product_id: stripeProduct.id
+                });
+
+                await this._StripePrice.add({
+                    stripe_price_id: stripePlan.id,
+                    stripe_product_id: stripeProduct.id,
+                    active: stripePlan.active,
+                    nickname: stripePlan.nickname,
+                    currency: stripePlan.currency,
+                    amount: stripePlan.amount,
+                    type: 'recurring',
+                    interval: stripePlan.interval
+                });
+
+                stripePlans.push(stripePlan);
+            }
+        }
+    }
+};

--- a/packages/members-api/lib/services/stripe-api/index.js
+++ b/packages/members-api/lib/services/stripe-api/index.js
@@ -393,6 +393,20 @@ module.exports = class StripeAPIService {
     }
 
     /**
+     * getPlan
+     *
+     * @param {string} id
+     * @param {object} options
+     *
+     * @returns {Promise<import('stripe').Stripe.Plan>}
+     */
+    async getPlan(id, options = {}) {
+        debug(`getSubscription(${id}, ${JSON.stringify(options)})`);
+
+        return await this._stripe.plans.retrieve(id, options);
+    }
+
+    /**
      * getSubscription.
      *
      * @param {string} id


### PR DESCRIPTION
On Ghost Boot, as part of configuring Stripe, this populates stripe products and prices for existing stripe customers in the newly created `stripe_prices` and `stripe_products` table, which allows us to map existing customers to default Ghost product and on current prices. The population script on boot is only run if we find -

- No rows in `stripe_products`
- No rows in `stripe_prices`
- One or more rows in `members_stripe_customers_subscriptions`