### PR TITLE
Updated link subscription to handle missing stripe data

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -97,8 +97,7 @@ module.exports = function MembersApi({
         MemberEmailChangeEvent,
         MemberStatusEvent,
         StripeCustomer,
-        StripeCustomerSubscription,
-        StripePrice
+        StripeCustomerSubscription
     });
 
     const eventRepository = new EventRepository({

--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -90,13 +90,15 @@ module.exports = function MembersApi({
         stripeAPIService,
         stripePlansService,
         logger,
+        productRepository,
         Member,
         MemberSubscribeEvent,
         MemberPaidSubscriptionEvent,
         MemberEmailChangeEvent,
         MemberStatusEvent,
         StripeCustomer,
-        StripeCustomerSubscription
+        StripeCustomerSubscription,
+        StripePrice
     });
 
     const eventRepository = new EventRepository({

--- a/packages/members-api/lib/repositories/member/index.js
+++ b/packages/members-api/lib/repositories/member/index.js
@@ -283,7 +283,7 @@ module.exports = class MemberRepository {
 
             // Link Stripe Product & Price to Ghost Product
             if (ghostProduct) {
-                const productUpdateData = Object.assign({
+                await this._productRepository.update({
                     id: ghostProduct.get('id'),
                     name: ghostProduct.get('name'),
                     stripe_prices: [
@@ -298,8 +298,7 @@ module.exports = class MemberRepository {
                             interval: (subscriptionPriceData.recurring && subscriptionPriceData.recurring.interval) || null
                         }
                     ]
-                });
-                await this._productRepository.update(productUpdateData, options);
+                }, options);
             } else {
                 // Log error if now Ghost products found
                 this._logging.error(`There was an error linking subscription - ${subscription.id}, no Products exist.`);

--- a/packages/members-api/lib/repositories/member/index.js
+++ b/packages/members-api/lib/repositories/member/index.js
@@ -300,7 +300,7 @@ module.exports = class MemberRepository {
                     ]
                 }, options);
             } else {
-                // Log error if now Ghost products found
+                // Log error if no Ghost products found
                 this._logging.error(`There was an error linking subscription - ${subscription.id}, no Products exist.`);
             }
         } catch (e) {

--- a/packages/members-api/lib/repositories/member/index.js
+++ b/packages/members-api/lib/repositories/member/index.js
@@ -9,7 +9,6 @@ module.exports = class MemberRepository {
      * @param {any} deps.MemberStatusEvent
      * @param {any} deps.StripeCustomer
      * @param {any} deps.StripeCustomerSubscription
-     * @param {any} deps.StripePrice
      * @param {any} deps.productRepository
      * @param {import('../../services/stripe-api')} deps.stripeAPIService
      * @param {import('../../services/stripe-plans')} deps.stripePlansService
@@ -23,7 +22,6 @@ module.exports = class MemberRepository {
         MemberStatusEvent,
         StripeCustomer,
         StripeCustomerSubscription,
-        StripePrice,
         stripeAPIService,
         stripePlansService,
         productRepository,
@@ -36,7 +34,6 @@ module.exports = class MemberRepository {
         this._MemberStatusEvent = MemberStatusEvent;
         this._StripeCustomer = StripeCustomer;
         this._StripeCustomerSubscription = StripeCustomerSubscription;
-        this._StripePrice = StripePrice;
         this._stripeAPIService = stripeAPIService;
         this._stripePlansService = stripePlansService;
         this._productRepository = productRepository;

--- a/packages/members-api/lib/repositories/product/index.js
+++ b/packages/members-api/lib/repositories/product/index.js
@@ -80,7 +80,7 @@ class ProductRepository {
             return await this._Product.findOne({slug: data.slug}, options);
         }
 
-        throw new Error('Missing id, slug, stripe_product_id, stripe_price_id from data');
+        throw new Error('Missing id, slug, stripe_product_id or stripe_price_id from data');
     }
 
     /**

--- a/packages/members-api/lib/repositories/product/index.js
+++ b/packages/members-api/lib/repositories/product/index.js
@@ -97,19 +97,6 @@ class ProductRepository {
      * @returns {Promise<ProductModel>}
      **/
     async create(data, options) {
-        if (data.product_id && data.stripe_product_id && this._stripeAPIService.configured) {
-            const product = await this._Product.findOne({id: data.product_id}, options);
-            if (product) {
-                await this._StripeProduct.add({
-                    product_id: product.get('id'),
-                    stripe_product_id: data.stripe_product_id
-                }, options);
-                await product.related('stripePrices').fetch(options);
-                return product;
-            } else {
-                throw new Error(`Could not find any Product matching ${data.product_id}`);
-            }
-        }
         const productData = {
             name: data.name
         };

--- a/packages/members-api/lib/repositories/product/index.js
+++ b/packages/members-api/lib/repositories/product/index.js
@@ -36,7 +36,7 @@ class ProductRepository {
     /**
      * Retrieves a Product by either stripe_product_id, stripe_price_id, id or slug
      *
-     * @param {{stripe_product_id: string} | {stripe_price_id: string} | {id: string} | {slug: string} | {limit: number}} data
+     * @param {{stripe_product_id: string} | {stripe_price_id: string} | {id: string} | {slug: string}} data
      * @param {object} options
      *
      * @returns {Promise<ProductModel>}
@@ -80,7 +80,7 @@ class ProductRepository {
             return await this._Product.findOne({slug: data.slug}, options);
         }
 
-        throw new Error('Missing id, slug, stripe_product_id, stripe_price_id or limit from data');
+        throw new Error('Missing id, slug, stripe_product_id, stripe_price_id from data');
     }
 
     /**

--- a/packages/members-api/lib/services/stripe-api/index.js
+++ b/packages/members-api/lib/services/stripe-api/index.js
@@ -436,6 +436,20 @@ module.exports = class StripeAPIService {
     }
 
     /**
+     * getPrice
+     *
+     * @param {string} id
+     * @param {object} options
+     *
+     * @returns {Promise<import('stripe').Stripe.Price>}
+     */
+    async getPrice(id, options = {}) {
+        debug(`getPrice(${id}, ${JSON.stringify(options)})`);
+
+        return await this._stripe.prices.retrieve(id, options);
+    }
+
+    /**
      * getPlan
      *
      * @param {string} id


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/619

On linking a stripe subscription to a member, this change -

- Adds missing stripe price or stripe product from subscription to DB
  - Missing Stripe price is attached to the first Ghost Product if no matching Product exists
- Updates usage from plan to price in the `linkSubscription` method
- Updated products associated with a member based on active subscriptions