### PR TITLE
Updated customer fetch from Stripe to include subscriptions

### DIFF
--- a/packages/members-api/lib/repositories/member/index.js
+++ b/packages/members-api/lib/repositories/member/index.js
@@ -216,9 +216,7 @@ module.exports = class MemberRepository {
         if (!this._stripeAPIService.configured) {
             throw new Error('Cannot link Stripe Customer with no Stripe Connection');
         }
-        const customer = await this._stripeAPIService.getCustomer(data.customer_id, {
-            expand: ['subscriptions']
-        });
+        const customer = await this._stripeAPIService.getCustomer(data.customer_id);
 
         if (!customer) {
             return;

--- a/packages/members-api/lib/services/stripe-api/index.js
+++ b/packages/members-api/lib/services/stripe-api/index.js
@@ -214,6 +214,11 @@ module.exports = class StripeAPIService {
         debug(`getCustomer(${id}, ${JSON.stringify(options)})`);
         try {
             await this._rateLimitBucket.throttle();
+            if (options.expand) {
+                options.expand.push('subscriptions');
+            } else {
+                options.expand = ['subscriptions'];
+            }
             const customer = await this._stripe.customers.retrieve(id, options);
             debug(`getCustomer(${id}, ${JSON.stringify(options)}) -> Success`);
             return customer;


### PR DESCRIPTION
refs https://github.com/TryGhost/Members/commit/79513c58b578a404d41f446274dc04263c33fd7c

Following up on last commit, this moves up the expansion of Stripe customer fetch to always include `subscriptions` by default in api service so we don't accidentally miss it.