### PR TITLE
Added labels and products to fetched member identity data

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -261,7 +261,15 @@ module.exports = function MembersApi({
     }
 
     async function getMemberIdentityData(email) {
-        const model = await users.get({email}, {withRelated: ['stripeSubscriptions', 'stripeSubscriptions.customer', 'stripeSubscriptions.stripePrice', 'stripeSubscriptions.stripePrice.stripeProduct', 'stripeSubscriptions.stripePrice.stripeProduct.product']});
+        const model = await users.get({email}, {withRelated: [
+            'stripeSubscriptions',
+            'stripeSubscriptions.customer',
+            'stripeSubscriptions.stripePrice',
+            'stripeSubscriptions.stripePrice.stripeProduct',
+            'stripeSubscriptions.stripePrice.stripeProduct.product',
+            'labels',
+            'products'
+        ]});
         if (!model) {
             return null;
         }


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/581
refs https://github.com/TryGhost/Team/issues/582

Content gating in Ghost is being expanded from basic public/members/free/paid to allowing full NQL queries. To facilitate quick matching of a member to the visibility query we need details of the associated labels and products alongside the basic member data.
