### PR TITLE
Added migration to revert portal_plans setting to named values

### DIFF
--- a/packages/members-api/index.js
+++ b/packages/members-api/index.js
@@ -167,6 +167,8 @@ module.exports = function MembersApi({
             return stripeMigrations.populateDefaultProductMonthlyPriceId();
         }).then(() => {
             return stripeMigrations.populateDefaultProductYearlyPriceId();
+        }).then(() => {
+            return stripeMigrations.revertPortalPlansSetting();
         }),
         stripeWebhookService.configure({
             webhookSecret: process.env.WEBHOOK_SECRET,


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/753

Currently, the portal_plans setting is storing price ids for active monthly/yearly prices for the default product, which was done to allow multiple prices in Portal. Since we only want to limit the prices for a Product to monthly/yearly, we are reverting the earlier migration and only store the available prices as monthly / yearly in portal setting instead of ids. Its also in sync with the approach in theme/API where we use named prices for monthly/yearly instead of price id list.