### PR TITLE
Supported products column for `parse` & `unparse`

### DIFF
--- a/packages/members-csv/lib/parse.js
+++ b/packages/members-csv/lib/parse.js
@@ -25,6 +25,12 @@ module.exports = (path, mapping, defaultLabels = []) => {
                     }
                 }
 
+                if (header === 'products') {
+                    if (value && typeof value === 'string') {
+                        return value.split(',').map(name => ({name}));
+                    }
+                }
+
                 if (header === 'subscribed') {
                     return value.toLowerCase() !== 'false';
                 }

--- a/packages/members-csv/lib/unparse.js
+++ b/packages/members-csv/lib/unparse.js
@@ -12,7 +12,8 @@ const unparse = (members) => {
         'stripe_customer_id',
         'created_at',
         'deleted_at',
-        'labels'
+        'labels',
+        'products'
     ]);
     const mappedMembers = members.map((member) => {
         if (member.error) {
@@ -28,6 +29,14 @@ const unparse = (members) => {
             }).join(',');
         }
 
+        let products = '';
+
+        if (Array.isArray(member.products)) {
+            products = member.products.map((product) => {
+                return product.name;
+            }).join(',');
+        }
+
         return {
             id: member.id,
             email: member.email,
@@ -39,6 +48,7 @@ const unparse = (members) => {
             created_at: member.created_at,
             deleted_at: member.deleted_at,
             labels: labels,
+            products: products,
             error: member.error || null
         };
     });

--- a/packages/members-csv/test/unparse.test.js
+++ b/packages/members-csv/test/unparse.test.js
@@ -13,7 +13,7 @@ describe('unparse', function () {
 
         should.exist(result);
 
-        const expected = `id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels\r\n,email@example.com,Sam Memberino,Early supporter,,,,,,`;
+        const expected = `id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,products\r\n,email@example.com,Sam Memberino,Early supporter,,,,,,,`;
         should.equal(result, expected);
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/765

Support for multiple products means we can no longer map a members state
to a csv row using just the `complimentary_plan` option. Instead we must
include the product(s) that a member has. This ensures that we can read
and write this data from/to csv files.