### PR TITLE
Added migration to remove invalid subscriptions

### DIFF
--- a/packages/members-api/MembersAPI.js
+++ b/packages/members-api/MembersAPI.js
@@ -168,6 +168,8 @@ module.exports = function MembersAPI({
             return stripeMigrations.populateDefaultProductYearlyPriceId();
         }).then(() => {
             return stripeMigrations.revertPortalPlansSetting();
+        }).then(() => {
+            return stripeMigrations.removeInvalidSubscriptions();
         }),
         stripeWebhookService.configure({
             webhookSecret: process.env.WEBHOOK_SECRET,


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/660

All subscriptions in Ghost are expected to have a corresponding price details in `stripe_price` table, which is used to determine the Stripe price a subscription is on. In some edge cases, specially before we started deleted old Stripe data during Stripe disconnect, it's possible that a subscription exists in DB without having a corresponding Stripe price in the DB. These subscriptions are not active for the connected Stripe account, and are save to remove. Going forward, all existing subscriptions with connected account will be removed when disconnecting stripe so we shouldn't have invalid subscriptions in DB in future.

The goal of this migration is to clean all such subscriptions from the DB to avoid any issues around missing price with invalid subscriptions.