### PR TITLE
Fixed _removeSessionCookie method use of `cookies`

### DIFF
--- a/packages/members-ssr/lib/MembersSSR.js
+++ b/packages/members-ssr/lib/MembersSSR.js
@@ -108,7 +108,7 @@ class MembersSSR {
      */
     _removeSessionCookie(req, res) {
         const cookies = this._getCookies(req, res);
-        cookies.set(this.sessionCookieName, this.sessionCookieOptions);
+        cookies.set(this.sessionCookieName, null, this.sessionCookieOptions);
     }
 
     /**


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/908

The `cookies` module will unset a cookie if `null` or `undefined` is
passed as the value, or if the value is not passed. The previous call
was passing the options, which were being read as the value, and
resulting in `'[Object object]'` being stored as a cookie.

Explicitly passing `null` as the value makes this code correct and
easier to maintain.