### PR TITLE
Fixed loading of relations for Product on creation

### DIFF
--- a/packages/members-api/lib/repositories/product.js
+++ b/packages/members-api/lib/repositories/product.js
@@ -208,10 +208,10 @@ class ProductRepository {
                 }
             }
 
-            await product.related('stripePrices').fetch(options);
-            await product.related('monthlyPrice').fetch(options);
-            await product.related('yearlyPrice').fetch(options);
-            await product.related('benefits').fetch(options);
+            return this._Product.findOne({id: product.id}, {
+                ...options,
+                withRelated: ['stripePrices', 'monthlyPrice', 'yearlyPrice', 'benefits']
+            });
         }
 
         return product;


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/919

For some reason the call to `product.related('benefits').fetch()` was
generating invalid SQL ("SELECT `undefined`.*") which was causing the
response to error.

This was definitely not the case before, and for whatever reason,
loading the relations via `withRelated` alleviates the issue.