### PR TITLE
Removed superfluous benefits relation fetch

### DIFF
--- a/packages/members-api/lib/repositories/product.js
+++ b/packages/members-api/lib/repositories/product.js
@@ -211,7 +211,6 @@ class ProductRepository {
             await product.related('stripePrices').fetch(options);
             await product.related('monthlyPrice').fetch(options);
             await product.related('yearlyPrice').fetch(options);
-            await product.related('benefits').fetch(options);
         }
 
         return product;


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/919

As we pass the `benefits` to the Product model on creation, we do not
need to manually fetch them again. In fact doing so causes a strange SQL
error, where we attempt to run `SELECT undefined.*`.