### PR TITLE
Added optional includes for member session data

### DIFF
--- a/packages/members-ssr/lib/MembersSSR.js
+++ b/packages/members-ssr/lib/MembersSSR.js
@@ -161,12 +161,13 @@ class MembersSSR {
      * @method _getMemberIdentityData
      *
      * @param {string} email
+     * @param {object} options
      *
      * @returns {Promise<Member>} member
      */
-    async _getMemberIdentityData(email) {
+    async _getMemberIdentityData(email, options) {
         const api = await this._getMembersApi();
-        return api.getMemberIdentityData(email);
+        return api.getMemberIdentityData(email, options);
     }
 
     /**
@@ -254,8 +255,8 @@ class MembersSSR {
      */
     async getMemberDataFromSession(req, res) {
         const email = this._getSessionCookies(req, res);
-
-        const member = await this._getMemberIdentityData(email);
+        const {include} = req.query;
+        const member = await this._getMemberIdentityData(email, {include});
         return member;
     }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/909

Fetching member session data currently returns pre-defined data points for a member, which is hardcoded deep in members api layer atm. This change allows easy access to several other optional member data fields via `include` options instead of needing a change in members-api everytime