### PR TITLE
Removed labels from member identity data

### DIFF
--- a/packages/members-api/lib/MembersAPI.js
+++ b/packages/members-api/lib/MembersAPI.js
@@ -270,7 +270,6 @@ module.exports = function MembersAPI({
             withRelated: [
                 'stripeSubscriptions',
                 'stripeSubscriptions.stripePrice',
-                'labels',
                 'products'
             ]
         });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/909
refs https://github.com/TryGhost/Ghost/commit/c36e749820bae58309791f969c67c12f387b96b8
refs https://github.com/TryGhost/Ghost/pull/13179

Labels were added to member identity data to allow for content gating posts with custom segments like labels and products. Going forward, for near future, we want to use only products for content gating, so fetching unused `labels` data for a member on each page load is no longer necessary and adds an extra DB request. This change removes `labels` from the list of related data returned for member identity on frontend.