### PR TITLE
Fixed status when subscriptions are canceled

### DIFF
--- a/packages/members-api/lib/repositories/member.js
+++ b/packages/members-api/lib/repositories/member.js
@@ -478,6 +478,10 @@ module.exports = class MemberRepository {
                     return product.id !== ghostProduct.id;
                 });
             }
+
+            if (memberProducts.length === 0) {
+                status = 'free';
+            }
         }
         let updatedMember;
         try {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/959

Because we were using the pre-existing products to determine a members
status, instead of the products _after_ we have handled the updates to
subscriptions, members with a paid subscription which was later canceled
were changed to 'comped' rather than 'free'. This adds a final check to
set a member to 'free' if their new set of products is empty.