### PR TITLE
Added ability to fetch member by identity token

### DIFF
--- a/packages/members-api/lib/MembersAPI.js
+++ b/packages/members-api/lib/MembersAPI.js
@@ -58,6 +58,12 @@ module.exports = function MembersAPI({
         common.logging.setLogger(logger);
     }
 
+    const tokenService = new TokenService({
+        privateKey,
+        publicKey,
+        issuer
+    });
+
     const stripeConfig = paymentConfig && paymentConfig.stripe || {};
 
     const stripeAPIService = new StripeAPIService({
@@ -90,6 +96,7 @@ module.exports = function MembersAPI({
     const memberRepository = new MemberRepository({
         stripeAPIService,
         logger,
+        tokenService,
         productRepository,
         Member,
         MemberSubscribeEvent,
@@ -126,12 +133,6 @@ module.exports = function MembersAPI({
         memberRepository,
         eventRepository,
         sendEmailWithMagicLink
-    });
-
-    const tokenService = new TokenService({
-        privateKey,
-        publicKey,
-        issuer
     });
 
     const geolocationService = new GeolocationSerice();

--- a/packages/members-api/lib/repositories/member.js
+++ b/packages/members-api/lib/repositories/member.js
@@ -12,6 +12,11 @@ const messages = {
     bulkActionRequiresFilter: 'Cannot perform {action} without a filter or all=true'
 };
 
+/**
+ * @typedef {object} ITokenService
+ * @prop {(token: string) => Promise<import('jsonwebtoken').JwtPayload>} decodeToken
+ */
+
 module.exports = class MemberRepository {
     /**
      * @param {object} deps
@@ -25,6 +30,7 @@ module.exports = class MemberRepository {
      * @param {any} deps.StripeCustomerSubscription
      * @param {any} deps.productRepository
      * @param {import('../../services/stripe-api')} deps.stripeAPIService
+     * @param {ITokenService} deps.tokenService
      * @param {any} deps.logger
      */
     constructor({
@@ -38,6 +44,7 @@ module.exports = class MemberRepository {
         StripeCustomerSubscription,
         stripeAPIService,
         productRepository,
+        tokenService,
         logger
     }) {
         this._Member = Member;
@@ -50,6 +57,7 @@ module.exports = class MemberRepository {
         this._StripeCustomerSubscription = StripeCustomerSubscription;
         this._stripeAPIService = stripeAPIService;
         this._productRepository = productRepository;
+        this.tokenService = tokenService;
         this._logging = logger;
     }
 
@@ -74,6 +82,14 @@ module.exports = class MemberRepository {
             return null;
         }
         return this._Member.findOne(data, options);
+    }
+
+    async getByToken(token, options) {
+        const data = await this.tokenService.decodeToken(token);
+
+        return this.get({
+            email: data.sub
+        }, options);
     }
 
     async create(data, options) {

--- a/packages/members-api/lib/services/token.js
+++ b/packages/members-api/lib/services/token.js
@@ -29,14 +29,21 @@ module.exports = class TokenService {
 
     /**
      * @param {string} token
+     * @returns {Promise<jwt.JwtPayload>}
      */
     async decodeToken(token) {
         await this._keyStoreReady;
 
-        return jwt.verify(token, this._publicKey, {
+        const result = jwt.verify(token, this._publicKey, {
             algorithms: ['RS512'],
             issuer: this._issuer
         });
+
+        if (typeof result === 'string') {
+            return {sub: result};
+        }
+
+        return result;
     }
 
     async getPublicKeys() {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1057

This method will validate a token, and then return the member associated
with it. Rather than exposing token validation and coupling consumers to
the structure of the token response data.