### PR TITLE
Updated MembersAPI to take StripeAPIService as dep

### DIFF
--- a/packages/members-api/lib/MembersAPI.js
+++ b/packages/members-api/lib/MembersAPI.js
@@ -55,6 +55,7 @@ module.exports = function MembersAPI({
         Product,
         Settings
     },
+    stripeAPIService,
     logger,
     labsService
 }) {
@@ -69,16 +70,6 @@ module.exports = function MembersAPI({
     });
 
     const stripeConfig = paymentConfig && paymentConfig.stripe || {};
-
-    const stripeAPIService = new StripeAPIService({
-        config: {
-            secretKey: stripeConfig.secretKey,
-            publicKey: stripeConfig.publicKey,
-            appInfo: stripeConfig.appInfo,
-            enablePromoCodes: stripeConfig.enablePromoCodes
-        },
-        logger
-    });
 
     const memberAnalyticsService = MemberAnalyticsService.create(MemberAnalyticEvent);
     memberAnalyticsService.eventHandler.setupSubscribers();
@@ -198,7 +189,7 @@ module.exports = function MembersAPI({
         await StripeCustomer.forge().query().del();
     }
 
-    const ready = paymentConfig.stripe ? Promise.all([
+    const ready = stripeAPIService.configured ? Promise.all([
         stripeMigrations.populateProductsAndPrices().then(() => {
             return stripeMigrations.populateStripePricesFromStripePlansSetting(stripeConfig.plans);
         }).then(() => {

--- a/packages/members-api/lib/MembersAPI.js
+++ b/packages/members-api/lib/MembersAPI.js
@@ -3,7 +3,6 @@ const body = require('body-parser');
 const MagicLink = require('@tryghost/magic-link');
 const common = require('./common');
 
-const StripeAPIService = require('@tryghost/members-stripe-service');
 const MemberAnalyticsService = require('@tryghost/member-analytics-service');
 const MembersAnalyticsIngress = require('@tryghost/members-analytics-ingress');
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1083

The Offers service is going to need access to the StripeAPIService too,
so we must pull its initialisation out of this module up to the Ghost
application layer, which will allow us to pass a reference of the
StripeAPIService to wherever needs it.