### PR TITLE
Fixed incomplete subscription flow

### DIFF
--- a/packages/members-api/lib/repositories/member.js
+++ b/packages/members-api/lib/repositories/member.js
@@ -625,7 +625,7 @@ module.exports = class MemberRepository {
             } else {
                 status = 'paid';
             }
-            // This is a new subscription! Add the product
+            // This is an active subscription! Add the product
             if (ghostProduct) {
                 memberProducts.push(ghostProduct.toJSON());
             }


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1156

Because we were only attempting to add the product to the members if the
subscription was new AND active - we would not add it for incomplete
subscriptions transitioning to active.

Instead we always attempt to add the product to a member for an active
subscription - it doesn't matter if it's a new one. We later have logic
to filter out duplicate products if the member already has access to the
product.