### PR TITLE
🐛 Fixed 500 webhook errors for subscription with multiple prices

### DIFF
--- a/packages/members-api/lib/services/stripe-webhook.js
+++ b/packages/members-api/lib/services/stripe-webhook.js
@@ -142,9 +142,9 @@ module.exports = class StripeWebhookService {
             customer_id: subscription.customer
         });
         const subscriptionPriceData = _.get(subscription, 'items.data');
-        if (subscriptionPriceData && subscriptionPriceData.length > 1) {
+        if (!subscriptionPriceData || subscriptionPriceData.length !== 1) {
             throw new errors.BadRequestError({
-                message: 'Subscription cannot have more than 1 prices'
+                message: 'Subscription should have exactly 1 price item'
             });
         }
         if (member) {

--- a/packages/members-api/lib/services/stripe-webhook.js
+++ b/packages/members-api/lib/services/stripe-webhook.js
@@ -141,7 +141,12 @@ module.exports = class StripeWebhookService {
         const member = await this._memberRepository.get({
             customer_id: subscription.customer
         });
-
+        const subscriptionPriceData = _.get(subscription, 'items.data');
+        if (subscriptionPriceData && subscriptionPriceData.length > 1) {
+            throw new errors.BadRequestError({
+                message: 'Subscription cannot have more than 1 prices'
+            });
+        }
         if (member) {
             await this._memberRepository.linkSubscription({
                 id: member.id,

--- a/packages/members-api/test/unit/lib/services/stripe-webhook.test.js
+++ b/packages/members-api/test/unit/lib/services/stripe-webhook.test.js
@@ -42,4 +42,46 @@ describe('StripeWebhookService', function () {
             }
         });
     });
+    describe('customer.subscription.updated webhooks', function () {
+        it('Should throw a 400 error when a subscription has multiple prices', async function () {
+            const stripeWebhookService = new StripeWebhookService({
+                stripeAPIService: mock(StripeAPIService),
+                productRepository: mock(ProductRepository),
+                memberRepository: mock(MemberRepository)
+            });
+
+            stripeWebhookService._stripeAPIService.getSubscription.resolves({
+                customer: 'customer_id',
+                plan: {
+                    product: 'product_id'
+                }
+            });
+
+            stripeWebhookService._memberRepository.get.resolves(null);
+
+            stripeWebhookService._productRepository.get.resolves({
+                id: 'product_id'
+            });
+
+            try {
+                await stripeWebhookService.subscriptionEvent({
+                    items: {
+                        data: [
+                            {
+                                id: 'si_1',
+                                price: {}
+                            },
+                            {
+                                id: 'si_2',
+                                price: {}
+                            }
+                        ]
+                    }
+                });
+                should.fail();
+            } catch (err) {
+                should.equal(err.statusCode, 400);
+            }
+        });
+    });
 });

--- a/packages/members-api/test/unit/lib/services/stripe-webhook.test.js
+++ b/packages/members-api/test/unit/lib/services/stripe-webhook.test.js
@@ -83,5 +83,36 @@ describe('StripeWebhookService', function () {
                 should.equal(err.statusCode, 400);
             }
         });
+        it('Should throw a 400 error when a subscription has 0 prices', async function () {
+            const stripeWebhookService = new StripeWebhookService({
+                stripeAPIService: mock(StripeAPIService),
+                productRepository: mock(ProductRepository),
+                memberRepository: mock(MemberRepository)
+            });
+
+            stripeWebhookService._stripeAPIService.getSubscription.resolves({
+                customer: 'customer_id',
+                plan: {
+                    product: 'product_id'
+                }
+            });
+
+            stripeWebhookService._memberRepository.get.resolves(null);
+
+            stripeWebhookService._productRepository.get.resolves({
+                id: 'product_id'
+            });
+
+            try {
+                await stripeWebhookService.subscriptionEvent({
+                    items: {
+                        data: []
+                    }
+                });
+                should.fail();
+            } catch (err) {
+                should.equal(err.statusCode, 400);
+            }
+        });
     });
 });


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1238

- previously returned 500 errors when a subscription had multiple prices due to external tampering on Stripe directly
- instead now returns 400 Bad Request error in such scenario