### PR TITLE
Fixed the importer from overriding properties

### DIFF
--- a/packages/members-csv/lib/unparse.js
+++ b/packages/members-csv/lib/unparse.js
@@ -1,23 +1,23 @@
 const _ = require('lodash');
 const papaparse = require('papaparse');
+const DEFAULT_COLUMNS = [
+    'id',
+    'email',
+    'name',
+    'note',
+    'subscribed_to_emails',
+    'complimentary_plan',
+    'stripe_customer_id',
+    'created_at',
+    'deleted_at',
+    'labels',
+    'products'
+];
 
-const unparse = (members) => {
-    const columns = new Set([
-        'id',
-        'email',
-        'name',
-        'note',
-        'subscribed_to_emails',
-        'complimentary_plan',
-        'stripe_customer_id',
-        'created_at',
-        'deleted_at',
-        'labels',
-        'products'
-    ]);
+const unparse = (members, columns = DEFAULT_COLUMNS.slice()) => {
     const mappedMembers = members.map((member) => {
         if (member.error) {
-            columns.add('error');
+            columns.push('error');
         }
 
         let labels = '';
@@ -54,7 +54,7 @@ const unparse = (members) => {
     });
 
     return papaparse.unparse(mappedMembers, {
-        columns: Array.from(columns.values())
+        columns
     });
 };
 

--- a/packages/members-importer/lib/importer.js
+++ b/packages/members-importer/lib/importer.js
@@ -89,8 +89,9 @@ module.exports = class MembersCSVImporter {
         }
 
         const rows = await membersCSV.parse(inputFilePath, headerMapping, defaultLabels);
+        const columns = Object.keys(rows[0]);
         const numberOfBatches = Math.ceil(rows.length / batchSize);
-        const mappedCSV = membersCSV.unparse(rows);
+        const mappedCSV = membersCSV.unparse(rows, columns);
 
         const hasStripeData = rows.find(function rowHasStripeData(row) {
             return !!row.stripe_customer_id || !!row.complimentary_plan;

--- a/packages/members-importer/test/importer.test.js
+++ b/packages/members-importer/test/importer.test.js
@@ -202,5 +202,24 @@ describe('Importer', function () {
 
             fsWriteSpy.calledOnce.should.be.true();
         });
+
+        it('Does not include columns not in the original CSV or mapped', async function () {
+            const membersImporter = new MembersCSVImporter({
+                storagePath: csvPath,
+                getTimezone: sinon.stub().returns('UTC'),
+                getMembersApi: sinon.stub(),
+                sendEmail: sinon.stub(),
+                isSet: sinon.stub(),
+                addJob: sinon.stub(),
+                knex: sinon.stub(),
+                urlFor: sinon.stub()
+            });
+
+            await membersImporter.prepare(`${csvPath}/single-column-with-header.csv`);
+
+            const fileContents = fsWriteSpy.firstCall.args[1];
+
+            fileContents.should.match(/^email,labels\r\n/);
+        });
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1202

When importing we were transforming the CSV and add missing columns to
it before storing it in preparation to perform the import. This resulted
in the missing columns being updated for existing members with blank
data.

We've updated the Members CSV parsing library to take an options list of
columns to include, which then allows imports to not include all of the
default columns.