### PR TITLE
Handled new type column for tiers

### DIFF
--- a/packages/members-api/lib/migrations.js
+++ b/packages/members-api/lib/migrations.js
@@ -44,7 +44,8 @@ module.exports = class StripeMigrations {
         const products = productModels.toJSON();
         const {data} = await this._Product.findPage({
             ...options,
-            limit: 1
+            limit: 1,
+            filter: 'type:paid'
         });
         const defaultProduct = data[0] && data[0].toJSON();
 
@@ -142,7 +143,11 @@ module.exports = class StripeMigrations {
 
         if (!defaultStripeProduct) {
             logging.info('Could not find Stripe Product - creating one');
-            const productsPage = await this._Product.findPage({...options, limit: 1});
+            const productsPage = await this._Product.findPage({
+                ...options,
+                limit: 1,
+                filter: 'type:paid'
+            });
             const defaultProduct = productsPage.data[0];
             const stripeProduct = await this._stripeAPIService.createProduct({
                 name: defaultProduct.get('name')
@@ -417,7 +422,10 @@ module.exports = class StripeMigrations {
             });
         }
         logging.info('Migrating members_monthly_price_id setting to monthly_price_id column');
-        const productsPage = await this._Product.findPage({...options, limit: 1});
+        const productsPage = await this._Product.findPage({
+            ...options, limit: 1,
+            filter: 'type:paid'
+        });
         const defaultProduct = productsPage.data[0];
 
         if (defaultProduct.get('monthly_price_id')) {
@@ -438,7 +446,11 @@ module.exports = class StripeMigrations {
             });
         }
         logging.info('Migrating members_yearly_price_id setting to yearly_price_id column');
-        const productsPage = await this._Product.findPage({...options, limit: 1});
+        const productsPage = await this._Product.findPage({
+            ...options,
+            limit: 1,
+            filter: 'type:paid'
+        });
         const defaultProduct = productsPage.data[0];
 
         if (defaultProduct.get('yearly_price_id')) {

--- a/packages/members-api/lib/repositories/member.js
+++ b/packages/members-api/lib/repositories/member.js
@@ -564,7 +564,10 @@ module.exports = class MemberRepository {
             ghostProduct = await this._productRepository.get({stripe_product_id: subscriptionPriceData.product}, options);
             // Use first Ghost product as default product in case of missing link
             if (!ghostProduct) {
-                let {data: pageData} = await this._productRepository.list({limit: 1});
+                let {data: pageData} = await this._productRepository.list({
+                    limit: 1,
+                    filter: 'type:paid'
+                });
                 ghostProduct = (pageData && pageData[0]) || null;
             }
 
@@ -950,7 +953,12 @@ module.exports = class MemberRepository {
             return this.isActiveSubscriptionStatus(subscription.get('status'));
         });
 
-        const productPage = await this._productRepository.list({limit: 1, withRelated: ['stripePrices'], ...options});
+        const productPage = await this._productRepository.list({
+            limit: 1,
+            withRelated: ['stripePrices'],
+            filter: 'type:paid',
+            ...options
+        });
 
         const defaultProduct = productPage && productPage.data && productPage.data[0] && productPage.data[0].toJSON();
 

--- a/packages/members-api/lib/repositories/product.js
+++ b/packages/members-api/lib/repositories/product.js
@@ -507,7 +507,10 @@ class ProductRepository {
                 });
             });
         }
-        return this._Product.findPage(options);
+        return this._Product.findPage({
+            ...options,
+            filter: 'type:paid'
+        });
     }
 
     async destroy() {

--- a/packages/members-api/lib/repositories/product.js
+++ b/packages/members-api/lib/repositories/product.js
@@ -241,7 +241,6 @@ class ProductRepository {
      * @param {string} data.id
      * @param {string} data.name
      * @param {string} data.description
-     * @param {string} data.type
      * @param {BenefitInput[]} data.benefits
      *
      * @param {StripePriceInput[]=} data.stripe_prices

--- a/packages/members-api/lib/repositories/product.js
+++ b/packages/members-api/lib/repositories/product.js
@@ -507,8 +507,7 @@ class ProductRepository {
             });
         }
         return this._Product.findPage({
-            ...options,
-            filter: 'type:paid'
+            ...options
         });
     }
 

--- a/packages/members-api/lib/repositories/product.js
+++ b/packages/members-api/lib/repositories/product.js
@@ -108,6 +108,7 @@ class ProductRepository {
      * @param {StripePriceInput[]} data.stripe_prices
      * @param {StripePriceInput|null} data.monthly_price
      * @param {StripePriceInput|null} data.yearly_price
+     * @param {string} data.type
      * @param {string} data.product_id
      * @param {string} data.stripe_product_id
      *
@@ -133,6 +134,7 @@ class ProductRepository {
         }
 
         const productData = {
+            type: 'paid',
             name: data.name,
             description: data.description,
             benefits: data.benefits
@@ -140,7 +142,7 @@ class ProductRepository {
 
         const product = await this._Product.add(productData, options);
 
-        if (this._stripeAPIService.configured) {
+        if (this._stripeAPIService.configured && data.type !== 'free') {
             const stripeProduct = await this._stripeAPIService.createProduct({
                 name: productData.name
             });
@@ -240,6 +242,7 @@ class ProductRepository {
      * @param {string} data.id
      * @param {string} data.name
      * @param {string} data.description
+     * @param {string} data.type
      * @param {BenefitInput[]} data.benefits
      *
      * @param {StripePriceInput[]=} data.stripe_prices
@@ -278,7 +281,7 @@ class ProductRepository {
             id: data.id || options.id
         });
 
-        if (this._stripeAPIService.configured) {
+        if (this._stripeAPIService.configured && data.type !== 'free') {
             await product.related('stripeProducts').fetch(options);
 
             if (!product.related('stripeProducts').first()) {

--- a/packages/members-api/lib/repositories/product.js
+++ b/packages/members-api/lib/repositories/product.js
@@ -108,7 +108,6 @@ class ProductRepository {
      * @param {StripePriceInput[]} data.stripe_prices
      * @param {StripePriceInput|null} data.monthly_price
      * @param {StripePriceInput|null} data.yearly_price
-     * @param {string} data.type
      * @param {string} data.product_id
      * @param {string} data.stripe_product_id
      *
@@ -142,7 +141,7 @@ class ProductRepository {
 
         const product = await this._Product.add(productData, options);
 
-        if (this._stripeAPIService.configured && data.type !== 'free') {
+        if (this._stripeAPIService.configured) {
             const stripeProduct = await this._stripeAPIService.createProduct({
                 name: productData.name
             });
@@ -269,19 +268,26 @@ class ProductRepository {
                 });
             });
         }
+        const productId = data.id || options.id;
 
-        const productData = {
+        const existingProduct = await this._Product.findOne({id: productId}, options);
+
+        let productData = {
             name: data.name,
             description: data.description,
             benefits: data.benefits
         };
 
+        if (existingProduct.get('type') === 'free') {
+            delete productData.name;
+        }
+
         let product = await this._Product.edit(productData, {
             ...options,
-            id: data.id || options.id
+            id: productId
         });
 
-        if (this._stripeAPIService.configured && data.type !== 'free') {
+        if (this._stripeAPIService.configured && product.get('type') !== 'free') {
             await product.related('stripeProducts').fetch(options);
 
             if (!product.related('stripeProducts').first()) {

--- a/packages/members-api/lib/repositories/product.js
+++ b/packages/members-api/lib/repositories/product.js
@@ -506,9 +506,7 @@ class ProductRepository {
                 });
             });
         }
-        return this._Product.findPage({
-            ...options
-        });
+        return this._Product.findPage(options);
     }
 
     async destroy() {

--- a/packages/members-importer/lib/importer.js
+++ b/packages/members-importer/lib/importer.js
@@ -125,6 +125,7 @@ module.exports = class MembersCSVImporter {
         const membersApi = await this._getMembersApi();
 
         const defaultProductPage = await membersApi.productRepository.list({
+            filter: 'type:paid',
             limit: 1
         });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1037

Tiers have a new `type` column as to differentiate between `free` and `paid` tiers. This change -

- sets type as paid for all new tiers created, as `free` tier is created by default
- ignores any `type` changes for add/edit of tiers, as `free` tier is always included by default and all other tiers can only be `paid`
- excludes any price/stripe data change for free tier