### PR TITLE
Removed API verification logic

### DIFF
--- a/packages/verification-trigger/lib/verification-trigger.js
+++ b/packages/verification-trigger/lib/verification-trigger.js
@@ -1,6 +1,4 @@
 const errors = require('@tryghost/errors');
-const DomainEvents = require('@tryghost/domain-events');
-const {MemberSubscribeEvent} = require('@tryghost/member-events');
 
 const messages = {
     emailVerificationNeeded: `We're hard at work processing your import. To make sure you get great deliverability on a list of that size, we'll need to enable some extra features for your account. A member of our team will be in touch with you by email to review your account make sure everything is configured correctly so you're ready to go.`,
@@ -36,24 +34,6 @@ class VerificationTrigger {
         this._membersStats = membersStats;
         this._Settings = Settings;
         this._eventRepository = eventRepository;
-
-        DomainEvents.subscribe(MemberSubscribeEvent, async (event) => {
-            if (event.data.source === 'api' && isFinite(this._configThreshold)) {
-                const createdAt = new Date();
-                createdAt.setDate(createdAt.getDate() - 30);
-                const events = await this._eventRepository.getNewsletterSubscriptionEvents({
-                    // Date in last 30 days, source is API
-                    filter: `source:api+created_at:>'${createdAt.toISOString().replace('T', ' ').substring(0, 19)}'`
-                });
-
-                if (events.meta.pagination.total > this._configThreshold) {
-                    await this.startVerificationProcess({
-                        amountImported: events.meta.pagination.total,
-                        throwOnTrigger: false
-                    });
-                }
-            }
-        });
     }
 
     async getImportThreshold() {

--- a/packages/verification-trigger/test/verification-trigger.test.js
+++ b/packages/verification-trigger/test/verification-trigger.test.js
@@ -3,8 +3,6 @@
 const sinon = require('sinon');
 require('./utils');
 const VerificationTrigger = require('../lib/verification-trigger');
-const DomainEvents = require('@tryghost/domain-events');
-const {MemberSubscribeEvent} = require('@tryghost/member-events');
 
 describe('Import threshold', function () {
     it('Creates a threshold based on config', async function () {
@@ -153,39 +151,5 @@ describe('Email verification flow', function () {
             message: 'Email verification needed for site: {siteUrl}, just imported: {importedNumber} members.',
             amountImported: 10
         });
-    });
-
-    it('Triggers when a number of API events are dispatched', async function () {
-        const emailStub = sinon.stub().resolves(null);
-        const settingsStub = sinon.stub().resolves(null);
-        const eventStub = sinon.stub().resolves({
-            meta: {
-                pagination: {
-                    total: 10
-                }
-            }
-        });
-        
-        new VerificationTrigger({
-            configThreshold: 2,
-            Settings: {
-                edit: settingsStub
-            },
-            isVerified: () => false,
-            isVerificationRequired: () => false,
-            sendVerificationEmail: emailStub,
-            eventRepository: {
-                getNewsletterSubscriptionEvents: eventStub
-            }
-        });
-
-        DomainEvents.dispatch(MemberSubscribeEvent.create({
-            memberId: 'hello!',
-            source: 'api'
-        }, new Date()));
-
-        eventStub.callCount.should.eql(1);
-        eventStub.lastCall.firstArg.should.have.property('filter');
-        eventStub.lastCall.firstArg.filter.should.startWith('source:api+created_at:>');
     });
 });


### PR DESCRIPTION
no-issue

There is a bug in the event repository code where filters are not
correctly applied, this results in the api verification being extremely
trigger happy. For now we're removing the logic, with the plan to revert
this commit once the event repository is fixed.