### PR TITLE
Moved the last of the Stripe config out of Members

### DIFF
--- a/packages/members-api/lib/MembersAPI.js
+++ b/packages/members-api/lib/MembersAPI.js
@@ -28,7 +28,6 @@ module.exports = function MembersAPI({
         getSigninURL,
         tokenProvider
     },
-    paymentConfig,
     mail: {
         transporter,
         getText,
@@ -64,8 +63,6 @@ module.exports = function MembersAPI({
         publicKey,
         issuer
     });
-
-    const stripeConfig = paymentConfig && paymentConfig.stripe || {};
 
     const memberAnalyticsService = MemberAnalyticsService.create(MemberAnalyticEvent);
     memberAnalyticsService.eventHandler.setupSubscribers();
@@ -157,13 +154,7 @@ module.exports = function MembersAPI({
         stripeAPIService,
         tokenService,
         sendEmailWithMagicLink,
-        labsService,
-        config: {
-            checkoutSuccessUrl: stripeConfig.checkoutSuccessUrl,
-            checkoutCancelUrl: stripeConfig.checkoutCancelUrl,
-            billingSuccessUrl: stripeConfig.billingSuccessUrl,
-            billingCancelUrl: stripeConfig.billingCancelUrl
-        }
+        labsService
     });
 
     const wellKnownController = new WellKnownController({

--- a/packages/members-api/lib/controllers/router.js
+++ b/packages/members-api/lib/controllers/router.js
@@ -16,7 +16,6 @@ module.exports = class RouterController {
      * @param {import('@tryghost/members-stripe-service')} deps.stripeAPIService
      * @param {any} deps.tokenService
      * @param {{isSet(name: string): boolean}} deps.labsService
-     * @param {any} deps.config
      */
     constructor({
         offersAPI,
@@ -29,8 +28,7 @@ module.exports = class RouterController {
         stripeAPIService,
         tokenService,
         sendEmailWithMagicLink,
-        labsService,
-        config
+        labsService
     }) {
         this._offersAPI = offersAPI;
         this._paymentsService = paymentsService;
@@ -43,7 +41,6 @@ module.exports = class RouterController {
         this._tokenService = tokenService;
         this._sendEmailWithMagicLink = sendEmailWithMagicLink;
         this.labsService = labsService;
-        this._config = config;
     }
 
     async ensureStripe(_req, res, next) {
@@ -105,8 +102,8 @@ module.exports = class RouterController {
         }
 
         const session = await this._stripeAPIService.createCheckoutSetupSession(customer, {
-            successUrl: req.body.successUrl || this._config.billingSuccessUrl,
-            cancelUrl: req.body.cancelUrl || this._config.billingCancelUrl,
+            successUrl: req.body.successUrl,
+            cancelUrl: req.body.cancelUrl,
             subscription_id: req.body.subscription_id
         });
         const publicKey = this._stripeAPIService.getPublicKey();
@@ -197,8 +194,8 @@ module.exports = class RouterController {
 
         const member = email ? await this._memberRepository.get({email}, {withRelated: ['stripeCustomers', 'products']}) : null;
 
-        let successUrl = req.body.successUrl || this._config.checkoutSuccessUrl;
-        let cancelUrl = req.body.cancelUrl || this._config.checkoutCancelUrl;
+        let successUrl = req.body.successUrl;
+        let cancelUrl = req.body.cancelUrl;
 
         if (!member && req.body.customerEmail && !req.body.successUrl) {
             const memberExistsForCustomer = await this._memberRepository.get({email: req.body.customerEmail});

--- a/packages/stripe/lib/StripeAPI.js
+++ b/packages/stripe/lib/StripeAPI.js
@@ -20,6 +20,10 @@ const STRIPE_API_VERSION = '2020-08-27';
  * @prop {string} secretKey
  * @prop {string} publicKey
  * @prop {boolean} enablePromoCodes
+ * @prop {string} checkoutSessionSuccessUrl
+ * @prop {string} checkoutSessionCancelUrl
+ * @prop {string} checkoutSetupSessionSuccessUrl
+ * @prop {string} checkoutSetupSessionCancelUrl
  */
 
 module.exports = class StripeAPI {
@@ -353,8 +357,8 @@ module.exports = class StripeAPI {
         }
         const session = await this._stripe.checkout.sessions.create({
             payment_method_types: ['card'],
-            success_url: options.successUrl,
-            cancel_url: options.cancelUrl,
+            success_url: options.successUrl || this._config.checkoutSessionSuccessUrl,
+            cancel_url: options.cancelUrl || this._config.checkoutSessionCancelUrl,
             customer_email: customerEmail,
             // @ts-ignore - we need to update to latest stripe library to correctly use newer features
             allow_promotion_codes: discounts ? undefined : this._config.enablePromoCodes,
@@ -391,8 +395,8 @@ module.exports = class StripeAPI {
         const session = await this._stripe.checkout.sessions.create({
             mode: 'setup',
             payment_method_types: ['card'],
-            success_url: options.successUrl,
-            cancel_url: options.cancelUrl,
+            success_url: options.successUrl || this._config.checkoutSetupSessionSuccessUrl,
+            cancel_url: options.cancelUrl || this._config.checkoutSetupSessionCancelUrl,
             customer_email: customer.email,
             setup_intent_data: {
                 metadata: {

--- a/packages/stripe/lib/StripeService.js
+++ b/packages/stripe/lib/StripeService.js
@@ -70,7 +70,11 @@ module.exports = class StripeService {
         this.api.configure({
             secretKey: config.secretKey,
             publicKey: config.publicKey,
-            enablePromoCodes: config.enablePromoCodes
+            enablePromoCodes: config.enablePromoCodes,
+            checkoutSessionSuccessUrl: config.checkoutSessionSuccessUrl,
+            checkoutSessionCancelUrl: config.checkoutSessionCancelUrl,
+            checkoutSetupSessionSuccessUrl: config.checkoutSetupSessionSuccessUrl,
+            checkoutSetupSessionCancelUrl: config.checkoutSetupSessionCancelUrl
         });
 
         await this.webhookManager.configure({

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -22,6 +22,7 @@
     "@babel/eslint-parser": "7.16.5",
     "c8": "7.11.0",
     "mocha": "9.1.3",
+    "rewire": "^6.0.0",
     "should": "13.2.3",
     "sinon": "11.1.2"
   },

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing c8 --reporter text --reporter cobertura --check-coverage mocha './test/**/*.test.js'",
+    "test": "NODE_ENV=testing c8 --lines 60 --reporter text --reporter cobertura --check-coverage mocha './test/**/*.test.js'",
     "lint": "eslint . --ext .js --cache",
     "posttest": "yarn lint"
   },

--- a/packages/stripe/test/unit/lib/StripeAPI.test.js
+++ b/packages/stripe/test/unit/lib/StripeAPI.test.js
@@ -1,0 +1,45 @@
+const sinon = require('sinon');
+const should = require('should');
+const rewire = require('rewire');
+const StripeAPI = rewire('../../../lib/StripeAPI');
+const api = new StripeAPI();
+
+describe('StripeAPI', function () {
+    let mockStripe;
+    beforeEach(function () {
+        mockStripe = {
+            checkout: {
+                sessions: {
+                    create: sinon.stub().resolves()
+                }
+            }
+        };
+        const mockStripeConstructor = sinon.stub().returns(mockStripe);
+        StripeAPI.__set__('Stripe', mockStripeConstructor);
+        api.configure({
+            checkoutSessionSuccessUrl: '/success',
+            checkoutSessionCancelUrl: '/cancel',
+            checkoutSetupSessionSuccessUrl: '/setup-success',
+            checkoutSetupSessionCancelUrl: '/setup-cancel',
+            secretKey: ''
+        });
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('createCheckoutSession sends success_url and cancel_url', async function (){
+        await api.createCheckoutSession('priceId', null, {});
+
+        should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.success_url);
+        should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
+    });
+
+    it('createCheckoutSetupSession sends success_url and cancel_url', async function (){
+        await api.createCheckoutSetupSession('priceId', {});
+
+        should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.success_url);
+        should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1746,7 +1746,7 @@ eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint@7.32.0:
+eslint@7.32.0, eslint@^7.32.0:
   version "7.32.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.32.0.tgz#c6d328a14be3fb08c8d1d21e12c02fdb7a2a812d"
   integrity sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
@@ -4171,6 +4171,13 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+rewire@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/rewire/-/rewire-6.0.0.tgz#54f4fcda4df9928d28af1eb54a318bc51ca9aa99"
+  integrity sha512-7sZdz5dptqBCapJYocw9EcppLU62KMEqDLIILJnNET2iqzXHaQfaVP5SOJ06XvjX+dNIDJbzjw0ZWzrgDhtjYg==
+  dependencies:
+    eslint "^7.32.0"
 
 rimraf@2.6.3:
   version "2.6.3"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1322

We no longer restart the Members service based on the Stripe service
being updated, which meant that if it was initially configured with
missing URL's and later Stripe connected, it would not get the new
config until a server restart. This moves the last of Stripe config into
the Stripe service, so that all things concerning Stripe can be handled
in one place and updated together.