### PR TITLE
🐛 Fixed 500 error when creating product benefits without name

### DIFF
--- a/packages/members-api/lib/repositories/product.js
+++ b/packages/members-api/lib/repositories/product.js
@@ -4,7 +4,9 @@ const tpl = require('@tryghost/tpl');
 const messages = {
     priceMustBeInteger: 'Tier prices must be an integer.',
     priceIsNegative: 'Tier prices must not be negative',
-    maxPriceExceeded: 'Tier prices may not exceed 999999.99'
+    maxPriceExceeded: 'Tier prices may not exceed 999999.99',
+    benefitNameRequired: 'Benefit name is required',
+    benefitNameMustBeString: 'Benefit name must be a string'
 };
 
 /**
@@ -43,6 +45,27 @@ function validatePrice(price) {
     if (price.amount > 9999999999) {
         throw new ValidationError({
             message: tpl(messages.maxPriceExceeded)
+        });
+    }
+}
+
+/**
+ * @param {BenefitInput} benefit
+ */
+function validateBenefit(benefit) {
+    if (!benefit.name) {
+        throw new ValidationError({
+            message: tpl(messages.benefitNameRequired)
+        });
+    }
+    if (typeof benefit.name !== 'string') {
+        throw new ValidationError({
+            message: tpl(messages.benefitNameMustBeString)
+        });
+    }
+    if (benefit.name.length === 0) {
+        throw new ValidationError({
+            message: tpl(messages.benefitNameRequired)
         });
     }
 }
@@ -172,6 +195,10 @@ class ProductRepository {
 
         if (data.stripe_prices) {
             data.stripe_prices.forEach(validatePrice);
+        }
+
+        if (data.benefits) {
+            data.benefits.forEach(validateBenefit);
         }
 
         const productData = {
@@ -322,6 +349,10 @@ class ProductRepository {
 
         if (data.stripe_prices) {
             data.stripe_prices.forEach(validatePrice);
+        }
+
+        if (data.benefits) {
+            data.benefits.forEach(validateBenefit);
         }
 
         const productId = data.id || options.id;

--- a/packages/members-api/lib/repositories/product.js
+++ b/packages/members-api/lib/repositories/product.js
@@ -15,20 +15,23 @@ const messages = {
 
 /**
  * @typedef {object} StripePriceInput
- * @param {string} nickname
- * @param {string} currency
- * @param {number} amount
- * @param {'recurring'|'one-time'} type
- * @param {string | null} interval
- * @param {string?} stripe_product_id
- * @param {string?} stripe_price_id
+ * @property {string} nickname
+ * @property {string} currency
+ * @property {number} amount
+ * @property {'recurring'|'one-time'} type
+ * @property {string | null} interval
+ * @property {string?} stripe_product_id
+ * @property {string?} stripe_price_id
  */
 
 /**
  * @typedef {object} BenefitInput
- * @param {string} name
+ * @property {string} name
  */
 
+/**
+ * @param {StripePriceInput} price
+ */
 function validatePrice(price) {
     if (!Number.isInteger(price.amount)) {
         throw new ValidationError({


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1188

Ghost throws a 500 error when creating  product benefits with an empty name. When calling the /products/ API endpoint with something like this in the product body:
```
"benefits": [{
  "name": ""
}],
```

It should only throw a 500 error unless something is seriously broken. An error like this should cause a 422 Validation Error instead.

PR with tests in main repo: https://github.com/TryGhost/Ghost/pull/14217