### PR TITLE
🐛 Fixed StripeAPI disconnection

### DIFF
--- a/packages/stripe/lib/StripeService.js
+++ b/packages/stripe/lib/StripeService.js
@@ -64,6 +64,8 @@ module.exports = class StripeService {
             stripe_coupon_id: null
         });
         await this.webhookManager.stop();
+
+        this.api.configure(null);
     }
 
     async configure(config) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/214

- After disconnecting Stripe API the `_configured` flag stayed as `true`, causing behaviors as if Stripe was still connnected.
- The `api.configure` method was never reachable when disconnecting Stripe API, thus causes hanging "configured === false" state inside of the StripeAPI wrapper