### PR TITLE
Added an updater for the `last_seen_at` member field

### DIFF
--- a/packages/member-events/index.js
+++ b/packages/member-events/index.js
@@ -5,5 +5,6 @@ module.exports = {
     MemberSignupEvent: require('./lib/MemberSignupEvent'),
     MemberPaidConverstionEvent: require('./lib/MemberPaidConversionEvent'),
     MemberPaidCancellationEvent: require('./lib/MemberPaidCancellationEvent'),
+    MemberPageViewEvent: require('./lib/MemberPageViewEvent'),
     SubscriptionCreatedEvent: require('./lib/SubscriptionCreatedEvent')
 };

--- a/packages/member-events/lib/MemberPageViewEvent.js
+++ b/packages/member-events/lib/MemberPageViewEvent.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {object} MemberPageViewEventData
+ * @prop {string} memberId
+ * @prop {string} memberLastSeenAt
+ * @prop {string} url
+ */
+
+/**
+ * Server-side event firing on page views (page, post, tags...)
+ */
+module.exports = class MemberPageViewEvent {
+    /**
+     * @param {MemberPageViewEventData} data
+     * @param {Date} timestamp
+     */
+    constructor(data, timestamp) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @param {MemberPageViewEventData} data
+     * @param {Date} [timestamp]
+     */
+    static create(data, timestamp) {
+        return new MemberPageViewEvent(data, timestamp || new Date);
+    }
+};

--- a/packages/members-events-service/.eslintrc.js
+++ b/packages/members-events-service/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/node'
+    ]
+};

--- a/packages/members-events-service/LICENSE
+++ b/packages/members-events-service/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2013-2022 Ghost Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/members-events-service/README.md
+++ b/packages/members-events-service/README.md
@@ -1,0 +1,44 @@
+# Members events service
+
+
+Contains member services that listen on specific events to perform actions:
+
+- Last-seen-at updater: Updates `members.last_seen_at` on a page/post view event
+
+## Install
+
+`npm install @tryghost/members-events-service --save`
+
+or
+
+`yarn add @tryghost/members-events-service`
+
+
+## Usage
+
+
+## Develop
+
+This is a mono repository, managed with [lerna](https://lernajs.io/).
+
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+
+## Run
+
+- `yarn dev`
+
+
+## Test
+
+- `yarn lint` run just eslint
+- `yarn test` run lint and tests
+
+
+
+
+# Copyright & License 
+
+Copyright (c) 2013-2022 Ghost Foundation - Released under the [MIT license](LICENSE).

--- a/packages/members-events-service/index.js
+++ b/packages/members-events-service/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib');

--- a/packages/members-events-service/lib/index.js
+++ b/packages/members-events-service/lib/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    LastSeenAtUpdater: require('./last-seen-at-updater')
+};

--- a/packages/members-events-service/lib/last-seen-at-updater.js
+++ b/packages/members-events-service/lib/last-seen-at-updater.js
@@ -1,0 +1,38 @@
+const DomainEvents = require('@tryghost/domain-events');
+const {MemberPageViewEvent} = require('@tryghost/member-events');
+const moment = require('moment');
+
+/**
+ * Listen for `MemberViewEvent` to update the `member.last_seen_at` timestamp
+ */
+class LastSeenAtUpdater {
+    /**
+     * Initializes the event subscriber
+     * @param {Object} deps dependencies
+     * @param {any} deps.memberModel The member model
+     */
+    constructor({memberModel}) {
+        this._memberModel = memberModel;
+        DomainEvents.subscribe(MemberPageViewEvent, async (event) => {
+            await this.updateLastSeenAt(event.data.memberId, event.data.memberLastSeenAt, event.timestamp);
+        });
+    }
+
+    /**
+     * Updates the member.last_seen_at field if it was updated more than 24 hours ago
+     * @param {string} memberId The id of the member to be udpated
+     * @param {string} memberLastSeenAt The previous last_seen_at property value for the current member
+     * @param {Date} timestamp The event timestamp
+     */
+    async updateLastSeenAt(memberId, memberLastSeenAt, timestamp) {
+        if (memberLastSeenAt === null || moment(timestamp).diff(memberLastSeenAt, 'hours') > 24) {
+            await this._memberModel.update({
+                last_seen_at: moment(timestamp).utc().format('YYYY-MM-DD HH:mm:ss')
+            }, {
+                id: memberId
+            });
+        }
+    }
+}
+
+module.exports = LastSeenAtUpdater;

--- a/packages/members-events-service/lib/last-seen-at-updater.js
+++ b/packages/members-events-service/lib/last-seen-at-updater.js
@@ -19,15 +19,18 @@ class LastSeenAtUpdater {
     }
 
     /**
-     * Updates the member.last_seen_at field if it was updated more than 24 hours ago
+     * Updates the member.last_seen_at field if it wasn't updated in the current UTC day yet
+     * Example: current time is 2022-02-28 18:00:00 UTC
+     * - memberLastSeenAt is 2022-02-27 23:00:00 UTC, timestamp is current time, then `last_seen_at` is set to the current time
+     * - memberLastSeenAt is 2022-02-28 01:00:00 UTC, timestamp is current time, then `last_seen_at` isn't changed
      * @param {string} memberId The id of the member to be udpated
      * @param {string} memberLastSeenAt The previous last_seen_at property value for the current member
      * @param {Date} timestamp The event timestamp
      */
     async updateLastSeenAt(memberId, memberLastSeenAt, timestamp) {
-        if (memberLastSeenAt === null || moment(timestamp).diff(memberLastSeenAt, 'hours') > 24) {
+        if (memberLastSeenAt === null || moment(moment.utc(timestamp).startOf('day')).isAfter(moment.utc(memberLastSeenAt).startOf('day'))) {
             await this._memberModel.update({
-                last_seen_at: moment(timestamp).utc().format('YYYY-MM-DD HH:mm:ss')
+                last_seen_at: moment.utc(timestamp).format('YYYY-MM-DD HH:mm:ss')
             }, {
                 id: memberId
             });

--- a/packages/members-events-service/package.json
+++ b/packages/members-events-service/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@tryghost/members-events-service",
+  "version": "0.0.0",
+  "repository": "https://github.com/TryGhost/Members/tree/main/packages/members-events-service",
+  "author": "Ghost Foundation",
+  "license": "MIT",
+  "main": "index.js",
+  "scripts": {
+    "dev": "echo \"Implement me!\"",
+    "test": "NODE_ENV=testing c8 --all --check-coverage mocha './test/**/*.test.js'",
+    "lint": "eslint . --ext .js --cache",
+    "posttest": "yarn lint"
+  },
+  "files": [
+    "index.js",
+    "lib"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "c8": "7.11.0",
+    "mocha": "9.2.1",
+    "should": "13.2.3",
+    "sinon": "13.0.1"
+  },
+  "dependencies": {
+    "@tryghost/domain-events": "^0.1.7",
+    "@tryghost/member-events": "^0.3.5",
+    "moment": "^2.29.1"
+  }
+}

--- a/packages/members-events-service/test/.eslintrc.js
+++ b/packages/members-events-service/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/test'
+    ]
+};

--- a/packages/members-events-service/test/last-seen-at-updater.test.js
+++ b/packages/members-events-service/test/last-seen-at-updater.test.js
@@ -1,0 +1,52 @@
+// Switch these lines once there are useful utils
+// const testUtils = require('./utils');
+require('./utils');
+
+const assert = require('assert');
+const sinon = require('sinon');
+const LastSeenAtUpdater = require('../lib/last-seen-at-updater');
+const DomainEvents = require('@tryghost/domain-events');
+const {MemberPageViewEvent, MemberSubscribeEvent} = require('@tryghost/member-events');
+
+describe('LastSeenAtUpdater', function () {
+    it('Fires on MemberPageViewEvent events', async function () {
+        const now = new Date();
+        const previousLastSeen = new Date(now.getTime() - 48 * 3600 * 1000).toISOString(); // 48 hours
+        const spy = sinon.spy();
+        new LastSeenAtUpdater({
+            memberModel: {
+                update: spy
+            }
+        });
+        DomainEvents.dispatch(MemberPageViewEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, url: '/'}, now));
+        assert(spy.calledOnceWithExactly({
+            last_seen_at: now.toISOString().replace('T', ' ').replace(/\..+/, '')
+        }, {
+            id: '1'
+        }), 'The LastSeenAtUpdater should attempt a member update with the current date.');
+    });
+
+    it('Doesn\'t update when last_seen_at is too recent', async function () {
+        const now = new Date();
+        const previousLastSeen = new Date(now.getTime() - 1 * 3600 * 1000).toISOString(); // 1 hour
+        const spy = sinon.spy();
+        new LastSeenAtUpdater({
+            memberModel: {
+                update: spy
+            }
+        });
+        DomainEvents.dispatch(MemberPageViewEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, url: '/'}, now));
+        assert(spy.notCalled, 'The LastSeenAtUpdater should\'t update a member when the previous last_seen_at is close to the event timestamp.');
+    });
+
+    it('Doesn\'t fire on other events', async function () {
+        const spy = sinon.spy();
+        new LastSeenAtUpdater({
+            memberModel: {
+                update: spy
+            }
+        });
+        DomainEvents.dispatch(MemberSubscribeEvent.create({memberId: '1', source: 'api'}, new Date()));
+        assert(spy.notCalled, 'The LastSeenAtUpdater should never fire on MemberPageViewEvent events.');
+    });
+});

--- a/packages/members-events-service/test/last-seen-at-updater.test.js
+++ b/packages/members-events-service/test/last-seen-at-updater.test.js
@@ -4,49 +4,51 @@ require('./utils');
 
 const assert = require('assert');
 const sinon = require('sinon');
-const LastSeenAtUpdater = require('../lib/last-seen-at-updater');
+const {LastSeenAtUpdater} = require('../');
 const DomainEvents = require('@tryghost/domain-events');
 const {MemberPageViewEvent, MemberSubscribeEvent} = require('@tryghost/member-events');
+const moment = require('moment');
 
 describe('LastSeenAtUpdater', function () {
     it('Fires on MemberPageViewEvent events', async function () {
-        const now = new Date();
-        const previousLastSeen = new Date(now.getTime() - 48 * 3600 * 1000).toISOString(); // 48 hours
+        const now = moment('2022-02-28T18:00:00Z').utc();
+        const previousLastSeen = moment('2022-02-27T23:00:00Z').toISOString();
         const spy = sinon.spy();
         new LastSeenAtUpdater({
             memberModel: {
                 update: spy
             }
         });
-        DomainEvents.dispatch(MemberPageViewEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, url: '/'}, now));
+        DomainEvents.dispatch(MemberPageViewEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, url: '/'}, now.toDate()));
         assert(spy.calledOnceWithExactly({
-            last_seen_at: now.toISOString().replace('T', ' ').replace(/\..+/, '')
+            last_seen_at: now.format('YYYY-MM-DD HH:mm:ss')
         }, {
             id: '1'
         }), 'The LastSeenAtUpdater should attempt a member update with the current date.');
     });
 
     it('Doesn\'t update when last_seen_at is too recent', async function () {
-        const now = new Date();
-        const previousLastSeen = new Date(now.getTime() - 1 * 3600 * 1000).toISOString(); // 1 hour
+        const now = moment('2022-02-28T18:00:00Z');
+        const previousLastSeen = moment('2022-02-28T00:00:00Z').toISOString();
         const spy = sinon.spy();
         new LastSeenAtUpdater({
             memberModel: {
                 update: spy
             }
         });
-        DomainEvents.dispatch(MemberPageViewEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, url: '/'}, now));
+        DomainEvents.dispatch(MemberPageViewEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, url: '/'}, now.toDate()));
         assert(spy.notCalled, 'The LastSeenAtUpdater should\'t update a member when the previous last_seen_at is close to the event timestamp.');
     });
 
     it('Doesn\'t fire on other events', async function () {
+        const now = moment('2022-02-28T18:00:00Z');
         const spy = sinon.spy();
         new LastSeenAtUpdater({
             memberModel: {
                 update: spy
             }
         });
-        DomainEvents.dispatch(MemberSubscribeEvent.create({memberId: '1', source: 'api'}, new Date()));
+        DomainEvents.dispatch(MemberSubscribeEvent.create({memberId: '1', source: 'api'}, now.toDate()));
         assert(spy.notCalled, 'The LastSeenAtUpdater should never fire on MemberPageViewEvent events.');
     });
 });

--- a/packages/members-events-service/test/utils/assertions.js
+++ b/packages/members-events-service/test/utils/assertions.js
@@ -1,0 +1,11 @@
+/**
+ * Custom Should Assertions
+ *
+ * Add any custom assertions to this file.
+ */
+
+// Example Assertion
+// should.Assertion.add('ExampleAssertion', function () {
+//     this.params = {operator: 'to be a valid Example Assertion'};
+//     this.obj.should.be.an.Object;
+// });

--- a/packages/members-events-service/test/utils/index.js
+++ b/packages/members-events-service/test/utils/index.js
@@ -1,0 +1,11 @@
+/**
+ * Test Utilities
+ *
+ * Shared utils for writing tests
+ */
+
+// Require overrides - these add globals for tests
+require('./overrides');
+
+// Require assertions - adds custom should assertions
+require('./assertions');

--- a/packages/members-events-service/test/utils/overrides.js
+++ b/packages/members-events-service/test/utils/overrides.js
@@ -1,0 +1,10 @@
+// This file is required before any test is run
+
+// Taken from the should wiki, this is how to make should global
+// Should is a global in our eslint test config
+global.should = require('should').noConflict();
+should.extend();
+
+// Sinon is a simple case
+// Sinon is a global in our eslint test config
+global.sinon = require('sinon');

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,7 +214,15 @@
     "@elastic/elasticsearch" "7.17.0"
     "@tryghost/debug" "^0.1.12"
 
-"@tryghost/errors@1.2.2", "@tryghost/errors@^1.0.0", "@tryghost/errors@^1.1.0", "@tryghost/errors@^1.1.1":
+"@tryghost/errors@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.2.3.tgz#dccfcd09e175e4f0e437039a2653119f84b41e70"
+  integrity sha512-6vd5s2tKX4uQoKjwyP7rICPVY3jj9balc5XLcmwQjUm4yuRAL9AAcpbf1O4AwNN1gs/cN+Wknxjk/LeeIvGbGA==
+  dependencies:
+    lodash "^4.17.21"
+    uuid "^8.3.2"
+
+"@tryghost/errors@^1.0.0", "@tryghost/errors@^1.1.0", "@tryghost/errors@^1.1.1":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.2.2.tgz#643009ba20770279577fe2778cdf1f816ad13e90"
   integrity sha512-81PnsWWayCLQgeBYpslyrMRmSIuflarxxR4tz7ZOIuptybAiKaD3S4GhTZLAXUOi38S62wJBoS/qTzRF6sIzng==


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1306

This introduces a new event: `MemberViewEvent`. And a listener that reacts to this event by updating the `member.last_seen_at` timestamp.

More details in the commits.