### PR TITLE
Removed default for visibility

### DIFF
--- a/packages/members-api/lib/repositories/product.js
+++ b/packages/members-api/lib/repositories/product.js
@@ -134,7 +134,7 @@ class ProductRepository {
      * @param {object} data
      * @param {string} data.name
      * @param {string} data.description
-     * @param {boolean} data.visibility
+     * @param {'public'|'none'} data.visibility
      * @param {string} data.welcome_page_url
      * @param {BenefitInput[]} data.benefits
      * @param {StripePriceInput[]} data.stripe_prices
@@ -288,7 +288,7 @@ class ProductRepository {
      * @param {string} data.id
      * @param {string} data.name
      * @param {string} data.description
-     * @param {boolean} data.visibility
+     * @param {'public'|'none'} data.visibility
      * @param {string} data.welcome_page_url
      * @param {BenefitInput[]} data.benefits
      *

--- a/packages/members-api/lib/repositories/product.js
+++ b/packages/members-api/lib/repositories/product.js
@@ -179,7 +179,7 @@ class ProductRepository {
         const productData = {
             type: 'paid',
             active: true,
-            visibility: data.visibility || false,
+            visibility: data.visibility,
             name: data.name,
             description: data.description,
             benefits: data.benefits,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1387

First, this default value didn't make sense as it was written when we
had a boolean visible column, second, we don't need to add defaults here
- this implementation is super tied to the models anyway, so we may as
well rely on the model defaults - if we do pull it out similar to
Offers, then it may make sense to add a default there.