### PR TITLE
Added migration to update Stripe Product names

### DIFF
--- a/packages/stripe/lib/StripeAPI.js
+++ b/packages/stripe/lib/StripeAPI.js
@@ -81,6 +81,18 @@ module.exports = class StripeAPI {
     }
 
     /**
+     * @param {string} id
+     *
+     * @returns {Promise<IProduct>}
+     */
+    async getProduct(id) {
+        await this._rateLimitBucket.throttle();
+        const product = await this._stripe.products.retrieve(id);
+
+        return product;
+    }
+
+    /**
      * @param {object} options
      * @param {string} options.name
      *

--- a/packages/stripe/test/unit/lib/Migrations.test.js
+++ b/packages/stripe/test/unit/lib/Migrations.test.js
@@ -1,0 +1,106 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const Migrations = require('../../../lib/Migrations');
+
+describe('Migrations', function () {
+    describe('updateStripeProductNamesFromDefaultProduct', function () {
+        it('Does not update Stripe product if name is not "Default Product"', async function () {
+            const api = {
+                getProduct: sinon.stub().resolves({
+                    id: 'prod_123',
+                    name: 'Bronze'
+                }),
+                updateProduct: sinon.stub().resolves()
+            };
+            const models = {
+                Product: {
+                    transaction: fn => fn()
+                },
+                StripeProduct: {
+                    findPage: sinon.stub().resolves({
+                        data: [{
+                            get(key) {
+                                return key;
+                            }
+                        }],
+                        meta: {}
+                    })
+                },
+                Settings: {
+                    findOne: sinon.stub().resolves({
+                        key: 'title',
+                        value: 'Site Title'
+                    })
+                }
+            };
+            const migrations = new Migrations({
+                models,
+                api
+            });
+
+            await migrations.updateStripeProductNamesFromDefaultProduct();
+
+            assert(
+                api.updateProduct.called === false,
+                'Stripe product should not be updated if name is not "Default Product"'
+            );
+        });
+
+        it('Updates the Stripe Product name if it is Default Product', async function () {
+            const api = {
+                getProduct: sinon.stub().resolves({
+                    id: 'prod_123',
+                    name: 'Default Product'
+                }),
+                updateProduct: sinon.stub().resolves()
+            };
+            const models = {
+                Product: {
+                    transaction: fn => fn()
+                },
+                StripeProduct: {
+                    findPage: sinon.stub().resolves({
+                        data: [{
+                            get(key) {
+                                return key;
+                            }
+                        }],
+                        meta: {}
+                    })
+                },
+                Settings: {
+                    findOne: sinon.stub().resolves({
+                        get(key) {
+                            if (key === 'key') {
+                                return 'title';
+                            }
+                            if (key === 'value') {
+                                return 'Site Title';
+                            }
+
+                            return key;
+                        }
+                    })
+                }
+            };
+            const migrations = new Migrations({
+                models,
+                api
+            });
+
+            await migrations.updateStripeProductNamesFromDefaultProduct();
+
+            assert(
+                api.updateProduct.calledOnce,
+                'Stripe product should be updated if name is "Default Product"'
+            );
+
+            assert(
+                api.updateProduct.calledWith('prod_123', {
+                    name: 'Site Title'
+                }),
+                'Stripe product should have been updated with the site title as name'
+            );
+        });
+    });
+});


### PR DESCRIPTION
no-issue

We had a bug where Tiers would have a name of 'Default Product', and a
Stripe Product would be created with the same name. This migration will
fixes those broken Stripe Products