### PR TITLE
Fixed 'labels is not defined on the model' error

### DIFF
--- a/packages/members-api/lib/services/member-bread.js
+++ b/packages/members-api/lib/services/member-bread.js
@@ -225,7 +225,7 @@ module.exports = class MemberBREADService {
                 await this.memberRepository.linkStripeCustomer({
                     customer_id: data.stripe_customer_id,
                     member_id: model.id
-                }, {...options, withRelated: undefined});
+                }, {...options, withRelated: []});
             }
         } catch (error) {
             const isStripeLinkingError = error.message && (error.message.match(/customer|plan|subscription/g));

--- a/packages/members-api/lib/services/member-bread.js
+++ b/packages/members-api/lib/services/member-bread.js
@@ -220,12 +220,16 @@ module.exports = class MemberBREADService {
             throw error;
         }
 
+        const sharedOptions = options.transacting ? {
+            transacting: options.transacting
+        } : {};
+
         try {
             if (data.stripe_customer_id) {
                 await this.memberRepository.linkStripeCustomer({
                     customer_id: data.stripe_customer_id,
                     member_id: model.id
-                }, {...options, withRelated: []});
+                }, sharedOptions);
             }
         } catch (error) {
             const isStripeLinkingError = error.message && (error.message.match(/customer|plan|subscription/g));
@@ -245,7 +249,7 @@ module.exports = class MemberBREADService {
 
         if (!this.labsService.isSet('multipleProducts')) {
             if (data.comped) {
-                await this.memberRepository.setComplimentarySubscription(model, options);
+                await this.memberRepository.setComplimentarySubscription(model, sharedOptions);
             }
         }
 

--- a/packages/members-api/lib/services/member-bread.js
+++ b/packages/members-api/lib/services/member-bread.js
@@ -225,7 +225,7 @@ module.exports = class MemberBREADService {
                 await this.memberRepository.linkStripeCustomer({
                     customer_id: data.stripe_customer_id,
                     member_id: model.id
-                }, options);
+                }, {...options, withRelated: undefined});
             }
         } catch (error) {
             const isStripeLinkingError = error.message && (error.message.match(/customer|plan|subscription/g));


### PR DESCRIPTION
no issue

- When: a new member is added via the API, with a stripe_customer_id.
- The member bread service's `add` method is called with a default option: `withRelated: ['labels']`.
- This option is passed along to the member repository (and consecutive calls) and is also passed when loading relations that don't have a relationship called 'labels'.
- This results in a `labels is not defined on the model` error when you try to create a new member with a stripe customer id.
- Test that found this issue will be added to the Ghost repo: https://github.com/TryGhost/Ghost/pull/14333