### PR TITLE
Reversed counting of member counts in events repository and included paid deltas

### DIFF
--- a/packages/members-api/lib/MembersAPI.js
+++ b/packages/members-api/lib/MembersAPI.js
@@ -94,6 +94,7 @@ module.exports = function MembersAPI({
 
     const eventRepository = new EventRepository({
         EmailRecipient,
+        Member,
         MemberSubscribeEvent,
         MemberPaidSubscriptionEvent,
         MemberPaymentEvent,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1458
refs https://github.com/TryGhost/Team/issues/1459
refs https://github.com/TryGhost/Team/issues/1372

Depends on https://github.com/TryGhost/Ghost/pull/14386

- The member counts are now counted in the reverse order, to prevent having wrong total counts when the events are not right.
- Also includes paid deltas for canceled and subscribed paid members, which is needed for dashboard 5.0