### PR TITLE
Fixed failing migration requests when client runs in a test mode

### DIFF
--- a/packages/stripe/lib/Migrations.js
+++ b/packages/stripe/lib/Migrations.js
@@ -22,7 +22,11 @@ module.exports = class StripeMigrations {
         if (!this.api._configured) {
             logging.info('Stripe not configured - skipping migrations');
             return;
+        } else if (this.api.testEnv) {
+            logging.info('Stripe is in test mode - skipping migrations');
+            return;
         }
+
         await this.populateProductsAndPrices();
         await this.populateStripePricesFromStripePlansSetting();
         await this.populateMembersMonthlyPriceIdSettings();

--- a/packages/stripe/lib/StripeAPI.js
+++ b/packages/stripe/lib/StripeAPI.js
@@ -24,6 +24,7 @@ const STRIPE_API_VERSION = '2020-08-27';
  * @prop {string} checkoutSessionCancelUrl
  * @prop {string} checkoutSetupSessionSuccessUrl
  * @prop {string} checkoutSetupSessionCancelUrl
+ * @prop {boolean} param.testEnv  - indicates if the module is run in test environment (note, NOT the test mode)
  */
 
 module.exports = class StripeAPI {
@@ -41,6 +42,10 @@ module.exports = class StripeAPI {
 
     get configured() {
         return this._configured;
+    }
+
+    get testEnv() {
+        return this._config.testEnv;
     }
 
     get mode() {

--- a/packages/stripe/lib/StripeService.js
+++ b/packages/stripe/lib/StripeService.js
@@ -76,7 +76,8 @@ module.exports = class StripeService {
             checkoutSessionSuccessUrl: config.checkoutSessionSuccessUrl,
             checkoutSessionCancelUrl: config.checkoutSessionCancelUrl,
             checkoutSetupSessionSuccessUrl: config.checkoutSetupSessionSuccessUrl,
-            checkoutSetupSessionCancelUrl: config.checkoutSetupSessionCancelUrl
+            checkoutSetupSessionCancelUrl: config.checkoutSetupSessionCancelUrl,
+            testEnv: config.testEnv
         });
 
         await this.webhookManager.configure({

--- a/packages/stripe/test/unit/lib/Migrations.test.js
+++ b/packages/stripe/test/unit/lib/Migrations.test.js
@@ -4,6 +4,61 @@ const Migrations = require('../../../lib/Migrations');
 
 describe('Migrations', function () {
     describe('updateStripeProductNamesFromDefaultProduct', function () {
+        it('Does not run migration if api is not configured', async function () {
+            const api = {
+                getProduct: sinon.stub().resolves({
+                    id: 'prod_123',
+                    name: 'Bronze'
+                }),
+                _configured: false
+            };
+            const models = {
+                Product: {
+                    transaction: sinon.spy()
+                }
+            };
+
+            const migrations = new Migrations({
+                models,
+                api
+            });
+
+            await migrations.execute();
+
+            assert(
+                models.Product.transaction.called === false,
+                'Stripe should not call any of the populateProductsAndPrices method parts if api is not configured'
+            );
+        });
+
+        it('Does not run migration if api is in test environment', async function () {
+            const api = {
+                getProduct: sinon.stub().resolves({
+                    id: 'prod_123',
+                    name: 'Bronze'
+                }),
+                _configured: true,
+                testEnv: true
+            };
+            const models = {
+                Product: {
+                    transaction: sinon.spy()
+                }
+            };
+
+            const migrations = new Migrations({
+                models,
+                api
+            });
+
+            await migrations.execute();
+
+            assert(
+                models.Product.transaction.called === false,
+                'Stripe should not call any of the populateProductsAndPrices method parts if api is not configured'
+            );
+        });
+
         it('Does not update Stripe product if name is not "Default Product"', async function () {
             const api = {
                 getProduct: sinon.stub().resolves({


### PR DESCRIPTION
no issue

- When Ghost is running in a test mode by default it is configured with an invalid Stripe key that looks like `sk_test***`. In this case the migrations still try runnig creating requiest to Stripe that fail. The failures pollute the log, which makes other valid errors to be lost.
- An example of such error log is following:
```
Invalid API Key provided: sk_test_******ripe

----------------------------------------

Error: Invalid API Key provided: sk_test_******ripe
    at res.toJSON.then.StripeAPIError.message (/home/naz/Workspace/Ghost/Ghost/node_modules/stripe/lib/StripeResource.js:214:23)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```
- There doesn't seem to be a good reason to do migrations in the test mode, so skipping them as a special case to fix the output pollution problem is a right solution


@allouis lemme know if you think there's a better way to achieve not calling Stripe or if there's a specific case when we'd want for the migrations to kick in in the test mode. Danke :pray: 