### PR TITLE
Used `FOR UPDATE` lock for linkSubscription reads

### DIFF
--- a/packages/members-api/lib/repositories/member.js
+++ b/packages/members-api/lib/repositories/member.js
@@ -562,7 +562,7 @@ module.exports = class MemberRepository {
         }
         const member = await this._Member.findOne({
             id: data.id
-        }, options);
+        }, {...options, forUpdate: true});
 
         const customer = await member.related('stripeCustomers').query({
             where: {
@@ -586,18 +586,19 @@ module.exports = class MemberRepository {
         }
         const paymentMethod = paymentMethodId ? await this._stripeAPIService.getCardPaymentMethod(paymentMethodId) : null;
 
-        const model = await this.getSubscriptionByStripeID(subscription.id, options);
+        const model = await this.getSubscriptionByStripeID(subscription.id, {...options, forUpdate: true});
 
         const subscriptionPriceData = _.get(subscription, 'items.data[0].price');
         let ghostProduct;
         try {
-            ghostProduct = await this._productRepository.get({stripe_product_id: subscriptionPriceData.product}, options);
+            ghostProduct = await this._productRepository.get({stripe_product_id: subscriptionPriceData.product}, {...options, forUpdate: true});
             // Use first Ghost product as default product in case of missing link
             if (!ghostProduct) {
                 let {data: pageData} = await this._productRepository.list({
                     limit: 1,
                     filter: 'type:paid',
-                    ...options
+                    ...options,
+                    forUpdate: true
                 });
                 ghostProduct = (pageData && pageData[0]) || null;
             }


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1248

blocked by https://github.com/TryGhost/Ghost/pull/14433

This fixes the issue with duplicate subscriptions being inserted because
concurrent calls to linkSubscription did not have rows locked.