### PR TITLE
Allow setting context for members importer and use correct source

### DIFF
--- a/packages/members-api/lib/repositories/member.js
+++ b/packages/members-api/lib/repositories/member.js
@@ -174,7 +174,7 @@ module.exports = class MemberRepository {
 
         if (context.internal) {
             source = 'system';
-        } else if (context.user) {
+        } else if (context.user || context.importer) {
             source = 'admin';
         } else if (context.api_key) {
             source = 'api';

--- a/packages/members-api/lib/repositories/member.js
+++ b/packages/members-api/lib/repositories/member.js
@@ -174,8 +174,10 @@ module.exports = class MemberRepository {
 
         if (context.internal) {
             source = 'system';
-        } else if (context.user || context.importer) {
+        } else if (context.user) {
             source = 'admin';
+        } else if (context.importer) {
+            source = 'importer';
         } else if (context.api_key) {
             source = 'api';
         } else {

--- a/packages/members-importer/lib/importer.js
+++ b/packages/members-importer/lib/importer.js
@@ -23,8 +23,9 @@ module.exports = class MembersCSVImporter {
      * @param {({name, at, job, data, offloaded}) => void} options.addJob - Method registering an async job
      * @param {Object} options.knex - An instance of the Ghost Database connection
      * @param {Function} options.urlFor - function generating urls
+     * @param {Object} options.context
      */
-    constructor({storagePath, getTimezone, getMembersApi, sendEmail, isSet, addJob, knex, urlFor}) {
+    constructor({storagePath, getTimezone, getMembersApi, sendEmail, isSet, addJob, knex, urlFor, context}) {
         this._storagePath = storagePath;
         this._getTimezone = getTimezone;
         this._getMembersApi = getMembersApi;
@@ -33,6 +34,7 @@ module.exports = class MembersCSVImporter {
         this._addJob = addJob;
         this._knex = knex;
         this._urlFor = urlFor;
+        this._context = context;
     }
 
     /**
@@ -134,7 +136,8 @@ module.exports = class MembersCSVImporter {
 
             const trx = await this._knex.transaction();
             const options = {
-                transacting: trx
+                transacting: trx,
+                context: this._context
             };
 
             try {

--- a/packages/members-importer/test/importer.test.js
+++ b/packages/members-importer/test/importer.test.js
@@ -69,7 +69,8 @@ describe('Importer', function () {
                 isSet: sinon.stub(),
                 addJob: sinon.stub(),
                 knex: knexStub,
-                urlFor: sinon.stub()
+                urlFor: sinon.stub(),
+                context: {importer: true}
             });
 
             const result = await importer.process({
@@ -109,7 +110,8 @@ describe('Importer', function () {
                 isSet: sinon.stub(),
                 addJob: sinon.stub(),
                 knex: sinon.stub(),
-                urlFor: sinon.stub()
+                urlFor: sinon.stub(),
+                context: {importer: true}
             });
 
             const result = await membersImporter.prepare(`${csvPath}/single-column-with-header.csv`);
@@ -132,7 +134,8 @@ describe('Importer', function () {
                 isSet: sinon.stub(),
                 addJob: sinon.stub(),
                 knex: sinon.stub(),
-                urlFor: sinon.stub()
+                urlFor: sinon.stub(),
+                context: {importer: true}
             });
 
             await membersImporter.prepare(`${csvPath}/single-column-with-header.csv`);


### PR DESCRIPTION
no issue

When importing members, the members-importer isn't aware of the context and therefore falls back to use `member` as a source in members event table. This makes it impossible to determine imported members from others.
- Added an `context` property to the options in the members-importer constructor
- Checked for `importer` context when creating member events and assigned the source `admin` to it