### PR TITLE
Stored offer_id in subscriptions

### DIFF
--- a/packages/members-api/lib/MembersAPI.js
+++ b/packages/members-api/lib/MembersAPI.js
@@ -92,7 +92,8 @@ module.exports = function MembersAPI({
         MemberProductEvent,
         OfferRedemption,
         StripeCustomer,
-        StripeCustomerSubscription
+        StripeCustomerSubscription,
+        offerRepository: offersAPI.repository
     });
 
     const eventRepository = new EventRepository({

--- a/packages/payments/lib/payments.js
+++ b/packages/payments/lib/payments.js
@@ -48,7 +48,11 @@ class PaymentsService {
         /** @type {import('stripe').Stripe.CouponCreateParams} */
         const couponData = {
             name: offer.name,
-            duration: offer.duration
+            duration: offer.duration,
+            // Note that the metadata is not present for older coupons
+            metadata: {
+                offer: offer.id
+            }
         };
 
         if (offer.duration === 'repeating') {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1519

- Added offer repository dependency to member repository (offerAPI didn't work because it creates a new transaction that resulted in a deadlock during tests)
- Store the offer id from the Stripe subscription metadata in the subscription (only if the discount is still active)
- Also added the offer id to the metadata for a Stripe coupon, this will make adding and removing coupons a bit more foolproof
- Prefer the usage of the offer metadata from a coupon if it is present
- When no discount is applied to a subscription, it always sets the offer id to null, even when the metadata still contains the offer
- The offer_id remains stored when a subscription is canceled/expired