### PR TITLE
Updated offer_id matching logic to use stripe_coupon_id instead of metadata

### DIFF
--- a/packages/offers/lib/application/OfferRepository.js
+++ b/packages/offers/lib/application/OfferRepository.js
@@ -142,6 +142,24 @@ class OfferRepository {
     }
 
     /**
+     * @param {string} id stripe_coupon_id
+     * @param {BaseOptions} [options]
+     * @returns {Promise<Offer>}
+     */
+    async getByStripeCouponId(id, options) {
+        const model = await this.OfferModel.findOne({stripe_coupon_id: id}, {
+            ...options,
+            withRelated: ['product']
+        });
+
+        if (!model) {
+            return null;
+        }
+
+        return this.mapToOffer(model, options);
+    }
+
+    /**
      * @param {ListOptions} options
      * @returns {Promise<Offer[]>}
      */

--- a/packages/payments/lib/payments.js
+++ b/packages/payments/lib/payments.js
@@ -48,11 +48,7 @@ class PaymentsService {
         /** @type {import('stripe').Stripe.CouponCreateParams} */
         const couponData = {
             name: offer.name,
-            duration: offer.duration,
-            // Note that the metadata is not present for older coupons
-            metadata: {
-                offer: offer.id
-            }
+            duration: offer.duration
         };
 
         if (offer.duration === 'repeating') {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1519

- Removed offer metadata again from offer (added in one of the previous commits)
- Added `getByStripeCouponId` method in offer repository (required to find an offer based on the stripe_coupon_id)
- Match discounts from Stripe based on the stripe_coupon_id instead of metadata