### PR TITLE
Fixed member webhooks

### DIFF
--- a/packages/members-events-service/lib/last-seen-at-updater.js
+++ b/packages/members-events-service/lib/last-seen-at-updater.js
@@ -9,17 +9,12 @@ class LastSeenAtUpdater {
     /**
      * Initializes the event subscriber
      * @param {Object} deps dependencies
-     * @param {Object} deps.models The list of model dependencies
-     * @param {any} deps.models.Member The Member model
      * @param {Object} deps.services The list of service dependencies
      * @param {any} deps.services.domainEvents The DomainEvents service
      * @param {any} deps.services.settingsCache The settings service
      * @param {() => object} deps.getMembersApi - A function which returns an instance of members-api
      */
     constructor({
-        models: {
-            Member
-        },
         services: {
             domainEvents,
             settingsCache
@@ -31,7 +26,6 @@ class LastSeenAtUpdater {
         }
 
         this._getMembersApi = getMembersApi;
-        this._memberModel = Member;
         this._domainEventsService = domainEvents;
         this._settingsCacheService = settingsCache;
 

--- a/packages/members-events-service/test/last-seen-at-updater.test.js
+++ b/packages/members-events-service/test/last-seen-at-updater.test.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 const {LastSeenAtUpdater} = require('../');
 const DomainEvents = require('@tryghost/domain-events');
-const {MemberPageViewEvent, MemberSubscribeEvent} = require('@tryghost/member-events');
+const {MemberPageViewEvent} = require('@tryghost/member-events');
 const moment = require('moment');
 
 describe('LastSeenAtUpdater', function () {

--- a/packages/members-events-service/test/last-seen-at-updater.test.js
+++ b/packages/members-events-service/test/last-seen-at-updater.test.js
@@ -24,7 +24,9 @@ describe('LastSeenAtUpdater', function () {
             },
             async getMembersApi() {
                 return {
-                    update: stub
+                    members: {
+                        update: stub
+                    }
                 };
             }
         });
@@ -47,7 +49,9 @@ describe('LastSeenAtUpdater', function () {
             },
             async getMembersApi() {
                 return {
-                    update: stub
+                    members: {
+                        update: stub
+                    }
                 };
             }
         });
@@ -69,7 +73,9 @@ describe('LastSeenAtUpdater', function () {
             },
             async getMembersApi() {
                 return {
-                    update: stub
+                    members: {
+                        update: stub
+                    }
                 };
             }
         });
@@ -95,7 +101,9 @@ describe('LastSeenAtUpdater', function () {
             },
             async getMembersApi() {
                 return {
-                    update: stub
+                    members: {
+                        update: stub
+                    }
                 };
             }
         });
@@ -116,7 +124,9 @@ describe('LastSeenAtUpdater', function () {
             },
             async getMembersApi() {
                 return {
-                    update: stub
+                    members: {
+                        update: stub
+                    }
                 };
             }
         });

--- a/packages/members-events-service/test/last-seen-at-updater.test.js
+++ b/packages/members-events-service/test/last-seen-at-updater.test.js
@@ -55,7 +55,7 @@ describe('LastSeenAtUpdater', function () {
         assert(stub.notCalled, 'The LastSeenAtUpdater should attempt a member update when the new timestamp is within the same day in the publication timezone.');
     });
 
-    it.only('works correctly on another timezone (updating last_seen_at)', async function () {
+    it('works correctly on another timezone (updating last_seen_at)', async function () {
         const now = moment('2022-02-28T04:00:00Z').utc();
         const previousLastSeen = moment('2022-02-27T20:00:00Z').toISOString();
         const stub = sinon.stub().resolves();

--- a/packages/members-events-service/test/last-seen-at-updater.test.js
+++ b/packages/members-events-service/test/last-seen-at-updater.test.js
@@ -10,74 +10,71 @@ const {MemberPageViewEvent, MemberSubscribeEvent} = require('@tryghost/member-ev
 const moment = require('moment');
 
 describe('LastSeenAtUpdater', function () {
-    it('Fires on MemberPageViewEvent events', async function () {
+    it('Calls updateLastSeenAt on MemberPageViewEvents', async function () {
         const now = moment('2022-02-28T18:00:00Z').utc();
         const previousLastSeen = moment('2022-02-27T23:00:00Z').toISOString();
-        const spy = sinon.spy();
+        const stub = sinon.stub().resolves();
         const settingsCache = sinon.stub().returns('Etc/UTC');
-        new LastSeenAtUpdater({
-            models: {
-                Member: {
-                    edit: spy
-                }
-            },
+        const updater = new LastSeenAtUpdater({
             services: {
                 settingsCache: {
                     get: settingsCache
                 },
                 domainEvents: DomainEvents
+            },
+            async getMembersApi() {
+                return {
+                    update: stub
+                };
             }
         });
+        sinon.stub(updater, 'updateLastSeenAt');
         DomainEvents.dispatch(MemberPageViewEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, url: '/'}, now.toDate()));
-        assert(spy.calledOnceWithExactly({
-            last_seen_at: now.format('YYYY-MM-DD HH:mm:ss')
-        }, {
-            id: '1'
-        }), 'The LastSeenAtUpdater should attempt a member update with the current date.');
+        assert(updater.updateLastSeenAt.calledOnceWithExactly('1', previousLastSeen, now.toDate()));
     });
 
     it('works correctly on another timezone (not updating last_seen_at)', async function () {
         const now = moment('2022-02-28T04:00:00Z').utc();
         const previousLastSeen = moment('2022-02-27T20:00:00Z').toISOString();
-        const spy = sinon.spy();
+        const stub = sinon.stub().resolves();
         const settingsCache = sinon.stub().returns('Asia/Bangkok');
-        new LastSeenAtUpdater({
-            models: {
-                Member: {
-                    edit: spy
-                }
-            },
+        const updater = new LastSeenAtUpdater({
             services: {
                 settingsCache: {
                     get: settingsCache
                 },
                 domainEvents: DomainEvents
+            },
+            async getMembersApi() {
+                return {
+                    update: stub
+                };
             }
         });
-        DomainEvents.dispatch(MemberPageViewEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, url: '/'}, now.toDate()));
-        assert(spy.notCalled, 'The LastSeenAtUpdater should attempt a member update when the new timestamp is within the same day in the publication timezone.');
+        await updater.updateLastSeenAt('1', previousLastSeen, now.toDate());
+        assert(stub.notCalled, 'The LastSeenAtUpdater should attempt a member update when the new timestamp is within the same day in the publication timezone.');
     });
 
-    it('works correctly on another timezone (updating last_seen_at)', async function () {
+    it.only('works correctly on another timezone (updating last_seen_at)', async function () {
         const now = moment('2022-02-28T04:00:00Z').utc();
         const previousLastSeen = moment('2022-02-27T20:00:00Z').toISOString();
-        const spy = sinon.spy();
+        const stub = sinon.stub().resolves();
         const settingsCache = sinon.stub().returns('Europe/Paris');
-        new LastSeenAtUpdater({
-            models: {
-                Member: {
-                    edit: spy
-                }
-            },
+        const updater = new LastSeenAtUpdater({
             services: {
                 settingsCache: {
                     get: settingsCache
                 },
                 domainEvents: DomainEvents
+            },
+            async getMembersApi() {
+                return {
+                    update: stub
+                };
             }
         });
-        DomainEvents.dispatch(MemberPageViewEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, url: '/'}, now.toDate()));
-        assert(spy.calledOnceWithExactly({
+        await updater.updateLastSeenAt('1', previousLastSeen, now.toDate());
+        assert(stub.calledOnceWithExactly({
             last_seen_at: now.format('YYYY-MM-DD HH:mm:ss')
         }, {
             id: '1'
@@ -87,43 +84,43 @@ describe('LastSeenAtUpdater', function () {
     it('Doesn\'t update when last_seen_at is too recent', async function () {
         const now = moment('2022-02-28T18:00:00Z');
         const previousLastSeen = moment('2022-02-28T00:00:00Z').toISOString();
-        const spy = sinon.spy();
+        const stub = sinon.stub().resolves();
         const settingsCache = sinon.stub().returns('Etc/UTC');
-        new LastSeenAtUpdater({
-            models: {
-                Member: {
-                    edit: spy
-                }
-            },
+        const updater = new LastSeenAtUpdater({
             services: {
                 settingsCache: {
                     get: settingsCache
                 },
                 domainEvents: DomainEvents
+            },
+            async getMembersApi() {
+                return {
+                    update: stub
+                };
             }
         });
-        DomainEvents.dispatch(MemberPageViewEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, url: '/'}, now.toDate()));
-        assert(spy.notCalled, 'The LastSeenAtUpdater should\'t update a member when the previous last_seen_at is close to the event timestamp.');
+        await updater.updateLastSeenAt('1', previousLastSeen, now.toDate());
+        assert(stub.notCalled, 'The LastSeenAtUpdater should\'t update a member when the previous last_seen_at is close to the event timestamp.');
     });
 
     it('Doesn\'t fire on other events', async function () {
         const now = moment('2022-02-28T18:00:00Z');
-        const spy = sinon.spy();
+        const stub = sinon.stub().resolves();
         const settingsCache = sinon.stub().returns('Etc/UTC');
-        new LastSeenAtUpdater({
-            models: {
-                Member: {
-                    edit: spy
-                }
-            },
+        const updater = new LastSeenAtUpdater({
             services: {
                 settingsCache: {
                     get: settingsCache
                 },
                 domainEvents: DomainEvents
+            },
+            async getMembersApi() {
+                return {
+                    update: stub
+                };
             }
         });
-        DomainEvents.dispatch(MemberSubscribeEvent.create({memberId: '1', source: 'api'}, now.toDate()));
-        assert(spy.notCalled, 'The LastSeenAtUpdater should never fire on MemberPageViewEvent events.');
+        await updater.updateLastSeenAt('1', undefined, now.toDate());
+        assert(stub.notCalled, 'The LastSeenAtUpdater should never fire on MemberPageViewEvent events.');
     });
 });


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1651488536238499

Changes needed in main repo:

1. **In `core/server/services/members/service.js`**
```
new LastSeenAtUpdater({
      models: {
          Member: models.Member
      },
      services: {
          domainEvents: DomainEvents,
          settingsCache
      },
      getMembersApi: () => module.exports.api
  });
 ```

2. **Add newsletters undefined protection in `core/server/api/canary/utils/serializers/output/members.js`**