### PR TITLE
Improved bulk unsubscribe operation to use member_id column

### DIFF
--- a/packages/members-api/lib/repositories/member.js
+++ b/packages/members-api/lib/repositories/member.js
@@ -617,13 +617,7 @@ module.exports = class MemberRepository {
         const memberIds = memberRows.map(row => row.id);
 
         if (data.action === 'unsubscribe') {
-            const memberNewsletterRows = await this._Member.getNewsletterRelations({
-                memberIds
-            });
-
-            const membersNewsletterIds = memberNewsletterRows.map(row => row.id);
-
-            return await this._Member.bulkDestroy(membersNewsletterIds, 'members_newsletters');
+            return await this._Member.bulkDestroy(memberIds, 'members_newsletters', {column: 'member_id'});
         }
 
         if (data.action === 'removeLabel') {


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1652980792270029
requires https://github.com/TryGhost/Ghost/pull/14870

When bulk unsubscribing members, the number of deleted newsletter relations are returned instead of the number of members with newsletters that were cleared. This update deletes newsletter relations on member_id, so we can return the count of members instead of newsletter relations that were deleted.