### PR TITLE
Fix kid missing from JWT header

### DIFF
--- a/packages/members-api/lib/services/token.js
+++ b/packages/members-api/lib/services/token.js
@@ -18,8 +18,8 @@ module.exports = class TokenService {
         const jwk = await this._keyStoreReady;
         return jwt.sign({
             sub,
-            kid: jwk.kid
         }, this._privateKey, {
+            keyid: jwk.kid,
             algorithm: 'RS512',
             audience: this._issuer,
             expiresIn: '10m',


### PR DESCRIPTION
The JWT should include a header field for _kid_ per the RFC. This fixes compatibility with libraries like pyjwt that rely on being able to fetch the public keys (jwks) and match them to the token (jws, jwt).