### PR TITLE
Updated DomainEvents to be non-singleton

### DIFF
--- a/packages/domain-events/README.md
+++ b/packages/domain-events/README.md
@@ -13,6 +13,7 @@ or
 
 ```js
 const DomainEvents = require('@tryghost/domain-events');
+const events = new DomainEvents();
 
 class MyEvent {
     constructor(message) {
@@ -23,13 +24,13 @@ class MyEvent {
     }
 }
 
-DomainEvents.subscribe(MyEvent, function handler(event) {
+events.subscribe(MyEvent, function handler(event) {
     console.log(event.data.message);
 });
 
 const event = new MyEvent('hello world');
 
-DomainEvents.dispatch(event);
+events.dispatch(event);
 ```
 
 

--- a/packages/domain-events/lib/DomainEvents.js
+++ b/packages/domain-events/lib/DomainEvents.js
@@ -17,7 +17,11 @@ class DomainEvents {
      * @private
      * @type EventEmitter
      */
-    static ee = new EventEmitter;
+    ee = null;
+
+    constructor() {
+        this.ee = new EventEmitter;
+    }
 
     /**
      * @template Data
@@ -27,8 +31,8 @@ class DomainEvents {
      *
      * @returns {void}
      */
-    static subscribe(Event, handler) {
-        DomainEvents.ee.on(Event.name, handler);
+    subscribe(Event, handler) {
+        this.ee.on(Event.name, handler);
     }
 
     /**
@@ -36,8 +40,8 @@ class DomainEvents {
      * @param {IEvent<Data>} event
      * @returns {void}
      */
-    static dispatch(event) {
-        DomainEvents.ee.emit(event.constructor.name, event);
+    dispatch(event) {
+        this.ee.emit(event.constructor.name, event);
     }
 }
 

--- a/packages/domain-events/test/DomainEvents.test.js
+++ b/packages/domain-events/test/DomainEvents.test.js
@@ -41,9 +41,11 @@ describe('DomainEvents', function () {
             }
         }
 
-        DomainEvents.subscribe(TestEvent, handler1);
-        DomainEvents.subscribe(TestEvent, handler2);
+        const events = new DomainEvents();
 
-        DomainEvents.dispatch(event);
+        events.subscribe(TestEvent, handler1);
+        events.subscribe(TestEvent, handler2);
+
+        events.dispatch(event);
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1438

Use this package as a singleton runs into issues when multiple
packages are depending on it. If we have multiple versions of this
package in use by dependencies, those using different version will be
unable to communicate, rendering this package essentially useless.

We're making a breaking change here, rather than just updating Ghost
to pass down the instance, as that will help us find missed packages
easier, as renovate will let us know.

As this is a breaking change to the interface, this will be a major
version bump.