### PR TITLE
Fixed support for `comped` flag in members

### DIFF
--- a/packages/members-api/lib/repositories/member.js
+++ b/packages/members-api/lib/repositories/member.js
@@ -1335,8 +1335,10 @@ module.exports = class MemberRepository {
      *
      * @param {Object} data
      * @param {String} data.id - member ID
+     * @param {Object} options
+     * @param {Object} [options.transacting]
      */
-    async cancelComplimentarySubscription({id}) {
+    async cancelComplimentarySubscription({id}, options) {
         if (!this._stripeAPIService.configured) {
             throw new errors.BadRequestError({message: tpl(messages.noStripeConnection, {action: 'cancel Complimentary Subscription'})});
         }
@@ -1357,7 +1359,7 @@ module.exports = class MemberRepository {
                     await this.linkSubscription({
                         id: id,
                         subscription: updatedSubscription
-                    });
+                    }, options);
                 } catch (err) {
                     logging.error(`There was an error cancelling subscription ${subscription.get('subscription_id')}`);
                     logging.error(err);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1674

- The `comped` flag was present in v3 Members API and was unintentionally dropped in v4/v5 APIs without noticing. The support is necessary to keep integrations like Zapier working. The flag should be phased out following the version header pattern that has been introduced in Ghost v5.

Egg, is this well placed or maybe could be showed in a different stage of "editing" the member? There's so many things going on in the create/update methods I decided to shove the change mostly by the end of methods to not disrupt anything accidentally.