### PR TITLE
Passed request referrer to magic link service

### DIFF
--- a/packages/magic-link/lib/MagicLink.js
+++ b/packages/magic-link/lib/MagicLink.js
@@ -24,7 +24,7 @@ class MagicLink {
      * @param {object} options
      * @param {MailTransporter} options.transporter
      * @param {TokenProvider<Token, TokenData>} options.tokenProvider
-     * @param {(token: Token, type: string, requestSrc?: string) => URL} options.getSigninURL
+     * @param {(token: Token, type: string, referrer?: string) => URL} options.getSigninURL
      * @param {typeof defaultGetText} [options.getText]
      * @param {typeof defaultGetHTML} [options.getHTML]
      * @param {typeof defaultGetSubject} [options.getSubject]
@@ -46,18 +46,17 @@ class MagicLink {
      *
      * @param {object} options
      * @param {string} options.email - The email to send magic link to
-     * @param {string} options.requestSrc - The source magic link was requested from
      * @param {TokenData} options.tokenData - The data for token
      * @param {string=} [options.type='signin'] - The type to be passed to the url and content generator functions
+     * @param {string=} [options.referrer=null] - The referrer of the request, if exists
      * @returns {Promise<{token: Token, info: SentMessageInfo}>}
      */
     async sendMagicLink(options) {
         const token = await this.tokenProvider.create(options.tokenData);
 
         const type = options.type || 'signin';
-        const requestSrc = options.requestSrc || '';
 
-        const url = this.getSigninURL(token, type, requestSrc);
+        const url = this.getSigninURL(token, type, options.referrer);
 
         const info = await this.transporter.sendMail({
             to: options.email,

--- a/packages/magic-link/test/index.test.js
+++ b/packages/magic-link/test/index.test.js
@@ -30,12 +30,13 @@ describe('MagicLink', function () {
                 tokenData: {
                     id: '420'
                 },
-                type: 'blazeit'
+                type: 'blazeit',
+                referrer: 'https://whatever.com'
             };
             const {token} = await service.sendMagicLink(args);
 
             should.ok(options.getSigninURL.calledOnce);
-            should.ok(options.getSigninURL.firstCall.calledWithExactly(token, 'blazeit', ''));
+            should.ok(options.getSigninURL.firstCall.calledWithExactly(token, 'blazeit', 'https://whatever.com'));
 
             should.ok(options.getText.calledOnce);
             should.ok(options.getText.firstCall.calledWithExactly('FAKEURL', 'blazeit', 'test@example.com'));

--- a/packages/members-api/lib/MembersAPI.js
+++ b/packages/members-api/lib/MembersAPI.js
@@ -169,7 +169,7 @@ module.exports = function MembersAPI({
 
     const users = memberRepository;
 
-    async function sendEmailWithMagicLink({email, requestedType, tokenData, options = {forceEmailType: false}, requestSrc = ''}) {
+    async function sendEmailWithMagicLink({email, requestedType, tokenData, options = {forceEmailType: false}, referrer = null}) {
         let type = requestedType;
         if (!options.forceEmailType) {
             const member = await users.get({email});
@@ -179,7 +179,7 @@ module.exports = function MembersAPI({
                 type = 'signup';
             }
         }
-        return magicLinkService.sendMagicLink({email, type, requestSrc, tokenData: Object.assign({email}, tokenData)});
+        return magicLinkService.sendMagicLink({email, type, tokenData: Object.assign({email}, tokenData), referrer});
     }
 
     function getMagicLink(email) {

--- a/packages/members-api/lib/controllers/router.js
+++ b/packages/members-api/lib/controllers/router.js
@@ -345,11 +345,11 @@ module.exports = class RouterController {
                 const member = await this._memberRepository.get({email});
                 if (member) {
                     const tokenData = {};
-                    await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType});
+                    await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType, referrer: req.get('referer')});
                 }
             } else {
                 const tokenData = _.pick(req.body, ['labels', 'name', 'newsletters']);
-                await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType});
+                await this._sendEmailWithMagicLink({email, tokenData, requestedType: emailType, referrer: req.get('referer')});
             }
             res.writeHead(201);
             return res.end('Created.');


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1174

This paves the way for Ghost to be able to redirect to the referrer
page when dealign with signup magic links. We pass the referrer for
all types of magic links however, to allow extension of this
functionality in the future.

We've also removed the concept of `requestSrc` which has been unused
for a while now.